### PR TITLE
Change CompletionConditions to use a FormSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Filter::options() should now return a \FormSchema\Schema\Form class
 - Filter::toArray() converts the FormSchema to a Vue Form Generator schema
 - Updated all filters supplied by the SDK
+- CompletionCondition::options() should now return a \FormSchema\Schema\Form class
+- ModuleBuilder calls toArray on the completion condition as opposed to casting itself.
+
+### Added
+- Implement CompletionCondition::toArray and ::toJson for converting completion conditions to array/json representations.
 
 ## [2.1] - (05/02/2020)
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -12,6 +12,9 @@ When upgrading, you should upgrade one version at a time.
 
 If you have created any custom filters, you will need to convert the options() function to return a \FormSchema\Schema\Form class.
 
+### Completion Conditions
+
+If you have created any completion conditions, you must change the options() function to return a \FormSchema\Schema\Form class instead of an array.
 ## [v2.0]
 
 ### Database User

--- a/src/Completion/Contracts/CompletionCondition.php
+++ b/src/Completion/Contracts/CompletionCondition.php
@@ -4,11 +4,15 @@ namespace BristolSU\Support\Completion\Contracts;
 
 use BristolSU\Support\ActivityInstance\ActivityInstance;
 use BristolSU\Support\ModuleInstance\Contracts\ModuleInstance;
+use FormSchema\Schema\Form;
+use FormSchema\Transformers\VFGTransformer;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
 
 /**
- * Completion Conditon class
+ * Completion Condition class
  */
-abstract class CompletionCondition
+abstract class CompletionCondition implements Arrayable, Jsonable
 {
     /**
      * The alias of the module the completion condition belongs to.
@@ -72,14 +76,12 @@ abstract class CompletionCondition
      * 
      * This allows for you to get user input to modify the behaviour of this class. For example, you could give an 
      * option of a 'number of files' to be approved before the condition is complete.
-     * [
-     *      'number_of_files' => 1
-     * ]
+     *
      * Any settings requested in here will be passed into the percentage or isComplete methods.
      * 
-     * @return array
+     * @return Form
      */
-    abstract public function options(): array;
+    abstract public function options(): Form;
 
     /**
      * A name for the completion condition
@@ -101,4 +103,19 @@ abstract class CompletionCondition
      * @return string
      */
     abstract public function alias(): string;
+
+    public function toJson($options = 0)
+    {
+        return json_encode($this->toArray(), $options);
+    }
+    
+    public function toArray()
+    {
+        return [
+            'name' => $this->name(),
+            'description' => $this->description(),
+            'options' => (new VFGTransformer())->transformToArray($this->options()),
+            'alias' => $this->alias()
+        ];
+    }
 }

--- a/src/Module/ModuleBuilder.php
+++ b/src/Module/ModuleBuilder.php
@@ -234,14 +234,7 @@ class ModuleBuilder implements ModuleBuilderContract
     public function setCompletionConditions()
     {
         $this->module->setCompletionConditions(
-            collect($this->completionConditionRepository->getAllForModule($this->getAlias()))->map(function(CompletionCondition $condition) {
-                return [
-                    'name' => $condition->name(),
-                    'description' => $condition->description(),
-                    'options' => $condition->options(),
-                    'alias' => $condition->alias()
-                ];
-            })->toArray()
+            collect($this->completionConditionRepository->getAllForModule($this->getAlias()))->toArray()
         );
     }
 }

--- a/tests/Completion/CompletionConditions/EventFired/EventFiredTest.php
+++ b/tests/Completion/CompletionConditions/EventFired/EventFiredTest.php
@@ -28,13 +28,17 @@ class EventFiredTest extends TestCase
         ]);
         
         $condition = new EventFired('module1', $eventRepository->reveal());
+
         
+        
+        $this->assertEquals(1, count($condition->options()->fields()));
+        $this->assertEquals('event_type', $condition->options()->fields()[0]->model());
+        $this->assertEquals('select', $condition->options()->fields()[0]->type());
         $this->assertEquals([
-            'event_type' => [
-                'event1' => 'name1',
-                'event2' => 'name2'
-            ]
-        ], $condition->options());
+            ['id' => 'event1', 'name' => 'name1'],
+            ['id' => 'event2', 'name' => 'name2'],
+        ], $condition->options()->fields()[0]->values());
+        
     }
     
     /** @test */

--- a/tests/Completion/Contracts/CompletionConditionTest.php
+++ b/tests/Completion/Contracts/CompletionConditionTest.php
@@ -6,6 +6,7 @@ use BristolSU\Support\ActivityInstance\ActivityInstance;
 use BristolSU\Support\Completion\Contracts\CompletionCondition;
 use BristolSU\Support\ModuleInstance\Contracts\ModuleInstance;
 use BristolSU\Support\Tests\TestCase;
+use FormSchema\Schema\Form;
 
 class CompletionConditionTest extends TestCase
 {
@@ -38,6 +39,51 @@ class CompletionConditionTest extends TestCase
         $this->assertEquals(0, $condition->percentage([], $activityInstance, $moduleInstance));
     }
     
+    /** @test */
+    public function toArray_returns_an_array_representation_of_the_condition(){
+        $condition = new DummyCondition('alias1');
+        
+        $array = $condition->toArray();
+
+        $this->assertArrayHasKey('name', $array);
+        $this->assertEquals('Name1', $array['name']);
+        
+        $this->assertArrayHasKey('description', $array);
+        $this->assertEquals('Desc1', $array['description']);
+
+        $this->assertArrayHasKey('alias', $array);
+        $this->assertEquals('alias1', $array['alias']);
+        
+        $this->assertArrayHasKey('options', $array);
+        $this->assertIsArray($array['options']);
+        $this->assertArrayHasKey('schema', $array['options']);
+    
+    }
+    
+    /** @test */
+    public function toJson_returns_a_json_representation_of_the_condition(){
+        $condition = new DummyCondition('alias1');
+
+        $json = $condition->toJson();
+
+        $this->assertJson($json);
+        
+        $arrayable = json_decode($json, true);
+
+        $this->assertArrayHasKey('name', $arrayable);
+        $this->assertEquals('Name1', $arrayable['name']);
+
+        $this->assertArrayHasKey('description', $arrayable);
+        $this->assertEquals('Desc1', $arrayable['description']);
+
+        $this->assertArrayHasKey('alias', $arrayable);
+        $this->assertEquals('alias1', $arrayable['alias']);
+
+        $this->assertArrayHasKey('options', $arrayable);
+        $this->assertIsArray($arrayable['options']);
+        $this->assertArrayHasKey('schema', $arrayable['options']);
+
+    }
 }
 
 class DummyCondition extends CompletionCondition {
@@ -54,19 +100,23 @@ class DummyCondition extends CompletionCondition {
         return $this->complete;
     }
 
-    public function options(): array
+    public function options(): Form
     {
+        return new Form();
     }
 
     public function name(): string
     {
+        return 'Name1';
     }
 
     public function description(): string
     {
+        return 'Desc1';
     }
 
     public function alias(): string
     {
+        return 'alias1';
     }
 }

--- a/tests/Module/ModuleBuilderTest.php
+++ b/tests/Module/ModuleBuilderTest.php
@@ -123,15 +123,13 @@ class ModuleBuilderTest extends TestCase
         $this->builder->create('alias1');
         
         $completionCondition1 = $this->prophesize(CompletionCondition::class);
-        $completionCondition1->name()->shouldBeCalled()->willReturn('name1');
-        $completionCondition1->description()->shouldBeCalled()->willReturn('desc1');
-        $completionCondition1->options()->shouldBeCalled()->willReturn(['option1' => 'val1']);
-        $completionCondition1->alias()->shouldBeCalled()->willReturn('ccalias1');
+        $completionCondition1->toArray()->shouldBeCalled()->willReturn([
+            'name' => 'name1', 'description' => 'desc1', 'options' => ['option1' => 'val1'], 'alias' => 'ccalias1'
+        ]);
         $completionCondition2 = $this->prophesize(CompletionCondition::class);
-        $completionCondition2->name()->shouldBeCalled()->willReturn('name2');
-        $completionCondition2->description()->shouldBeCalled()->willReturn('desc2');
-        $completionCondition2->options()->shouldBeCalled()->willReturn(['option2' => 'val2']);
-        $completionCondition2->alias()->shouldBeCalled()->willReturn('ccalias2');
+        $completionCondition2->toArray()->shouldBeCalled()->willReturn([
+            'name' => 'name2', 'description' => 'desc2', 'options' => ['option2' => 'val2'], 'alias' => 'ccalias2'
+        ]);
         
         $this->completionRepository->getAllForModule('alias1')->shouldBeCalled()->willReturn([$completionCondition1->reveal(), $completionCondition2->reveal()]);
         $this->module->setCompletionConditions([


### PR DESCRIPTION
Fix #9 

CompletionCondition::options() now must return a form schema not an array