### PR TITLE
Allow modules to specify a lowest resource that can use them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - enabled scope to a Module Instance model
 - \BristolSU\Support\ModuleInstance\ModuleInstanceRepository::allThroughActivity() to get all module instances for an activity
 - \BristolSU\Support\ModuleInstance\ModuleInstanceRepository::allEnabledThroughActivity() to get all enabled module instances for an activity
+- 'For' property to a Module model. This property is either user, group or role and allows modules to, e.g., require a group to be logged in to use the module.
 
 ## [2.1] - (05/02/2020)
 

--- a/src/Module/Contracts/Module.php
+++ b/src/Module/Contracts/Module.php
@@ -157,4 +157,21 @@ interface Module extends Arrayable, Jsonable
      * @return array
      */
     public function getServices(): array;
+
+    /**
+     * Set what resource the module is for. One of user, group or role.
+     * 
+     * @param string $for One of user, group or role
+     * 
+     * @return void
+     */
+    public function setFor(string $for = 'user');
+
+    /**
+     * Get what resource the module is for. One of user, group or role.
+     *
+     * @return string One of user, group or role
+     */
+    public function getFor(): string;   
+    
 }

--- a/src/Module/Contracts/ModuleBuilder.php
+++ b/src/Module/Contracts/ModuleBuilder.php
@@ -70,6 +70,15 @@ interface ModuleBuilder
      * @return void
      */
     public function setServices();
+
+    /**
+     * Set what resource the module is for
+     * 
+     * This should be one of user, group or role
+     * 
+     * @return void
+     */
+    public function setFor();
         
     /**
      * Get the built module

--- a/src/Module/Module.php
+++ b/src/Module/Module.php
@@ -10,42 +10,36 @@ use BristolSU\Support\Permissions\Contracts\Models\Permission;
  */
 class Module implements ModuleContract
 {
-
     /**
      * Alias of the module
      *
      * @var string
      */
     protected $alias;
-
     /**
      * Name of the module
-     * 
+     *
      * @var string
      */
     protected $name;
-
     /**
      * Description of the module
-     * 
+     *
      * @var string
      */
     protected $description;
-    
     /**
      * Permissions associated with the module
-     * 
+     *
      * @var Permission[]
      */
     protected $permissions;
-    
     /**
      * Settings associated with the module
-     * 
+     *
      * @var array Form schema
      */
     protected $settings;
-    
     /**
      * Triggerable events fired by the module for use with actions
      *
@@ -54,11 +48,10 @@ class Module implements ModuleContract
      *      'description' => 'Event Description',
      *      'event' => 'EventClassName'
      * ]
-     * 
+     *
      * @var array
      */
     protected $triggers;
-
     /**
      * Services the module requires or can use
      *
@@ -67,28 +60,57 @@ class Module implements ModuleContract
      *      'required' => ['typeform', 'facebook', ... ],
      *      'optional' => []
      * ]
-     * 
+     *
      * @var array
      */
     protected $services;
 
     /**
-     * Completion conditions used by the module
+     * Who the module is for. One of user, group or role
      * 
+     * @var string Who the module is for.
+     */
+    protected $for;
+    
+    /**
+     * Completion conditions used by the module
+     *
      * [
      *      'name' => '',
      *      'description' => '',
      *      'options' => [],
      *      'alias' => ''
      * ]
-     * 
+     *
      * @var array
      */
     protected $completionConditions;
 
     /**
+     * Set what resource the module is for. One of user, group or role.
+     *
+     * @param string $for One of user, group or role
+     *
+     * @return void
+     */
+    public function setFor(string $for = 'user')
+    {
+        $this->for = $for;
+    }
+
+    /**
+     * Get what resource the module is for. One of user, group or role.
+     *
+     * @return string One of user, group or role
+     */
+    public function getFor(): string
+    {
+        return ($this->for ?? 'user');
+    }
+
+    /**
      * Return the module as a json representation
-     * 
+     *
      * @return false|string
      */
     public function __toString()
@@ -98,7 +120,7 @@ class Module implements ModuleContract
 
     /**
      * Return the module as a json representation
-     * 
+     *
      * @param int $options
      * @return false|string
      */
@@ -121,7 +143,7 @@ class Module implements ModuleContract
      *      'completionConditions' => [],
      *      'services' => []
      * ]
-     * 
+     *
      * @return array
      */
     public function toArray()
@@ -134,13 +156,14 @@ class Module implements ModuleContract
             'settings' => $this->getSettings(),
             'triggers' => $this->getTriggers(),
             'completionConditions' => $this->getCompletionConditions(),
-            'services' => $this->getServices()
+            'services' => $this->getServices(),
+            'for' => $this->getFor()
         ];
     }
 
     /**
      * Get the alias of the module
-     * 
+     *
      * @return string
      */
     public function getAlias(): string
@@ -150,7 +173,7 @@ class Module implements ModuleContract
 
     /**
      * Set the alias of the module
-     * 
+     *
      * @param string $alias Alias of the module
      */
     public function setAlias(string $alias): void
@@ -160,7 +183,7 @@ class Module implements ModuleContract
 
     /**
      * Get the name of the module
-     * 
+     *
      * @return string Name
      */
     public function getName(): string
@@ -170,7 +193,7 @@ class Module implements ModuleContract
 
     /**
      * Set the name of the module
-     * 
+     *
      * @param string $name
      */
     public function setName(string $name): void
@@ -180,7 +203,7 @@ class Module implements ModuleContract
 
     /**
      * Get the description for the module
-     * 
+     *
      * @return string
      */
     public function getDescription(): string
@@ -190,7 +213,7 @@ class Module implements ModuleContract
 
     /**
      * Set the description for the module
-     * 
+     *
      * @param string $description
      */
     public function setDescription(string $description): void
@@ -200,7 +223,7 @@ class Module implements ModuleContract
 
     /**
      * Get the permissions for the module
-     * 
+     *
      * @return array
      */
     public function getPermissions(): array
@@ -210,7 +233,7 @@ class Module implements ModuleContract
 
     /**
      * Set the permissions for the module
-     * 
+     *
      * @param array $permissions
      */
     public function setPermissions(array $permissions): void
@@ -220,7 +243,7 @@ class Module implements ModuleContract
 
     /**
      * Get the settings for the module
-     * 
+     *
      * @return array
      */
     public function getSettings(): array
@@ -230,7 +253,7 @@ class Module implements ModuleContract
 
     /**
      * Set the settings for the module
-     * 
+     *
      * @param array $settings
      */
     public function setSettings(array $settings): void
@@ -240,13 +263,13 @@ class Module implements ModuleContract
 
     /**
      * Get the triggers for the module
-     * 
+     *
      * [
      *      'name' => 'Event Name',
      *      'description' => 'Event Description',
      *      'event' => 'EventClassName'
      * ]
-     * 
+     *
      * @return array
      */
     public function getTriggers(): array
@@ -256,13 +279,13 @@ class Module implements ModuleContract
 
     /**
      * Set the triggers for the module
-     * 
+     *
      * [
      *      'name' => 'Event Name',
      *      'description' => 'Event Description',
      *      'event' => 'EventClassName'
      * ]
-     * 
+     *
      * @param array $triggers
      */
     public function setTriggers(array $triggers): void
@@ -297,7 +320,7 @@ class Module implements ModuleContract
      *      'required' => ['typeform', 'facebook', ... ],
      *      'optional' => []
      * ]
-     * 
+     *
      * @return array
      */
     public function getServices(): array

--- a/src/Module/ModuleBuilder.php
+++ b/src/Module/ModuleBuilder.php
@@ -217,6 +217,18 @@ class ModuleBuilder implements ModuleBuilderContract
     }
 
     /**
+     * Set what resource the module requires.
+     * 
+     * @throws Exception If no alias is known by the builder
+     */
+    public function setFor()
+    {
+        $this->module->setFor(
+            $this->config->get($this->getAlias().'.for', 'user')
+        );
+    }
+    
+    /**
      * Get the built module
      * 
      * @return ModuleContract Initialised module

--- a/src/Module/ModuleFactory.php
+++ b/src/Module/ModuleFactory.php
@@ -30,6 +30,7 @@ class ModuleFactory implements ModuleFactoryAlias
         $moduleBuilder->setTriggers();
         $moduleBuilder->setCompletionConditions();
         $moduleBuilder->setServices();
+        $moduleBuilder->setFor();
         return $moduleBuilder->getModule();
     }
 }

--- a/tests/Module/ModuleBuilderTest.php
+++ b/tests/Module/ModuleBuilderTest.php
@@ -206,6 +206,15 @@ class ModuleBuilderTest extends TestCase
             $this->serviceRequest->reveal());
         $this->assertEquals('alias1', $builder->testGetAlias());
     }
+
+    /** @test */
+    public function setFor_sets_the_for_in_the_module(){
+        $this->builder->create('alias1');
+        $this->config->get('alias1.for', 'user')->shouldBeCalled()->willReturn('role');
+        $this->module->setFor('role')->shouldBeCalled();
+        $this->builder->setFor();
+    }
+
 }
 
 class Trigger implements TriggerableEvent

--- a/tests/Module/ModuleFactoryTest.php
+++ b/tests/Module/ModuleFactoryTest.php
@@ -24,6 +24,7 @@ class ModuleFactoryTest extends TestCase
         $builder->setSettings()->shouldBeCalled();
         $builder->setCompletionConditions()->shouldBeCalled();
         $builder->setServices()->shouldBeCalled();
+        $builder->setFor()->shouldBeCalled();
         $builder->getModule()->shouldBeCalled()->willReturn($module);
         $this->instance(ModuleBuilder::class, $builder->reveal());
         

--- a/tests/Module/ModuleTest.php
+++ b/tests/Module/ModuleTest.php
@@ -14,28 +14,32 @@ class ModuleTest extends TestCase
 {
 
     /** @test */
-    public function alias_has_setters_and_getters(){
+    public function alias_has_setters_and_getters()
+    {
         $module = new Module;
         $module->setAlias('alias1');
         $this->assertEquals('alias1', $module->getAlias());
     }
 
     /** @test */
-    public function name_has_setters_and_getters(){
+    public function name_has_setters_and_getters()
+    {
         $module = new Module;
         $module->setName('name1');
         $this->assertEquals('name1', $module->getName());
     }
 
     /** @test */
-    public function description_has_setters_and_getters(){
+    public function description_has_setters_and_getters()
+    {
         $module = new Module;
         $module->setDescription('description1');
         $this->assertEquals('description1', $module->getDescription());
     }
 
     /** @test */
-    public function permissions_have_setters_and_getters(){
+    public function permissions_have_setters_and_getters()
+    {
         $module = new Module;
         $module->setPermissions([
             'permission1'
@@ -44,7 +48,8 @@ class ModuleTest extends TestCase
     }
 
     /** @test */
-    public function settings_have_setters_and_getters(){
+    public function settings_have_setters_and_getters()
+    {
         $module = new Module;
         $module->setSettings([
             'setting1'
@@ -53,7 +58,8 @@ class ModuleTest extends TestCase
     }
 
     /** @test */
-    public function triggers_have_setters_and_getters(){
+    public function triggers_have_setters_and_getters()
+    {
         $module = new Module;
         $module->setTriggers([
             'trigger1', 'trigger2'
@@ -62,7 +68,8 @@ class ModuleTest extends TestCase
     }
 
     /** @test */
-    public function completion_conditions_have_setters_and_getters(){
+    public function completion_conditions_have_setters_and_getters()
+    {
         $module = new Module;
         $module->setCompletionConditions([
             'cc1', 'cc2'
@@ -71,14 +78,16 @@ class ModuleTest extends TestCase
     }
 
     /** @test */
-    public function service_request_has_setters_and_getters(){
+    public function service_request_has_setters_and_getters()
+    {
         $module = new Module;
         $module->setServices(['required' => ['facebook'], 'optional' => []]);
         $this->assertEquals(['required' => ['facebook'], 'optional' => []], $module->getServices());
     }
 
     /** @test */
-    public function toArray_returns_an_array_of_parameters(){
+    public function toArray_returns_an_array_of_parameters()
+    {
         $module = new Module;
         $module->setAlias('alias1');
         $module->setName('name1');
@@ -88,6 +97,7 @@ class ModuleTest extends TestCase
         $module->setTriggers(['trigger1']);
         $module->setCompletionConditions(['cc1']);
         $module->setServices(['required' => ['facebook'], 'optional' => []]);
+        $module->setFor('user');
 
         $this->assertEquals([
             'alias' => 'alias1',
@@ -97,12 +107,14 @@ class ModuleTest extends TestCase
             'settings' => ['setting1'],
             'triggers' => ['trigger1'],
             'completionConditions' => ['cc1'],
-            'services' => ['required' => ['facebook'], 'optional' => []]
+            'services' => ['required' => ['facebook'], 'optional' => []],
+            'for' => 'user'
         ], $module->toArray());
     }
 
     /** @test */
-    public function toJson_returns_a_json_encoded_array_of_parameters(){
+    public function toJson_returns_a_json_encoded_array_of_parameters()
+    {
         $module = new Module;
         $module->setAlias('alias1');
         $module->setName('name1');
@@ -112,6 +124,7 @@ class ModuleTest extends TestCase
         $module->setTriggers(['trigger1']);
         $module->setCompletionConditions(['cc1']);
         $module->setServices(['required' => ['facebook'], 'optional' => []]);
+        $module->setFor('group');
 
         $this->assertEquals(json_encode([
             'alias' => 'alias1',
@@ -121,12 +134,14 @@ class ModuleTest extends TestCase
             'settings' => ['setting1'],
             'triggers' => ['trigger1'],
             'completionConditions' => ['cc1'],
-            'services' => ['required' => ['facebook'], 'optional' => []]
+            'services' => ['required' => ['facebook'], 'optional' => []],
+            'for' => 'group'
         ]), $module->toJson());
     }
 
     /** @test */
-    public function __toString_returns_a_json_encoded_array_of_parameters(){
+    public function __toString_returns_a_json_encoded_array_of_parameters()
+    {
         $module = new Module;
         $module->setAlias('alias1');
         $module->setName('name1');
@@ -136,6 +151,7 @@ class ModuleTest extends TestCase
         $module->setTriggers(['trigger1']);
         $module->setCompletionConditions(['cc1']);
         $module->setServices(['required' => ['facebook'], 'optional' => []]);
+        $module->setFor('role');
 
         $this->assertEquals(json_encode([
             'alias' => 'alias1',
@@ -145,7 +161,16 @@ class ModuleTest extends TestCase
             'settings' => ['setting1'],
             'triggers' => ['trigger1'],
             'completionConditions' => ['cc1'],
-            'services' => ['required' => ['facebook'], 'optional' => []]
+            'services' => ['required' => ['facebook'], 'optional' => []],
+            'for' => 'role'
         ]), (string)$module);
+    }
+
+    /** @test */
+    public function for_has_setters_and_getters()
+    {
+        $module = new Module;
+        $module->setFor('group');
+        $this->assertEquals('group', $module->getFor());
     }
 }


### PR DESCRIPTION
Set a module for attribute to allow modules to specify what resource they require.

- Edit module factory to call the module builder setFor function
- Add a module builder setFor function to retrieve the for from the config, and default to user
- Add the 'for' attribute to the module model and to the array representation.

Any frontend realisation of the SDK should only show modules with the correct 'for' value.