### PR TITLE
Save the User ID for Actions, Activities, Module Instances and Logic Groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - enabled scope to a Module Instance model
 - \BristolSU\Support\ModuleInstance\ModuleInstanceRepository::allThroughActivity() to get all module instances for an activity
 - \BristolSU\Support\ModuleInstance\ModuleInstanceRepository::allEnabledThroughActivity() to get all enabled module instances for an activity
+- user_id column to an Activity, Module Instance, Action Instance and Logic Group
 
 ## [2.1] - (05/02/2020)
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -19,6 +19,11 @@ If you have created any completion conditions, you must change the options() fun
 ### Module Instances
 Module Instances should now be retrieved using the Module Instance Repository
 
+### User IDs
+In version 3, we introduce user IDs to the Activity, Action Instance, Logic and Module Instance models. Although this column is nullable, a null user ID will throw an exception when retrieved.
+
+To upgrade, ensure there are no null user IDs in the four tables. We recommend running a query to convert all null columns to contain your user ID.
+
 ## [v2.0]
 
 ### Database User

--- a/database/factories/ActionInstanceFactory.php
+++ b/database/factories/ActionInstanceFactory.php
@@ -26,5 +26,8 @@ $factory->define(ActionInstance::class, function(Faker $faker) {
         'module_instance_id' => function() {
             return factory(ModuleInstance::class)->create()->id;
         },
+        'user_id' => function() {
+            return factory(\BristolSU\ControlDB\Models\User::class)->create()->id();
+        }
     ];
 });

--- a/database/factories/ActivityFactory.php
+++ b/database/factories/ActivityFactory.php
@@ -29,7 +29,10 @@ $factory->define(Activity::class, function(Faker $faker) {
         'type' => 'open',
         'start_date' => $faker->dateTimeInInterval('-1 year', '-5 days'),
         'end_date' => $faker->dateTimeInInterval('+5 days', '+1 year'),
-        'enabled' => true
+        'enabled' => true,
+        'user_id' => function() {
+            return factory(\BristolSU\ControlDB\Models\User::class)->create()->id();
+        }
     ];
 });
 

--- a/database/factories/LogicFactory.php
+++ b/database/factories/LogicFactory.php
@@ -18,5 +18,8 @@ $factory->define(Logic::class, function(Faker $faker) {
     return [
         'name' => $faker->word,
         'description' => $faker->text,
+        'user_id' => function() {
+            return factory(\BristolSU\ControlDB\Models\User::class)->create()->id();
+        }
     ];
 });

--- a/database/factories/ModuleInstanceFactory.php
+++ b/database/factories/ModuleInstanceFactory.php
@@ -36,6 +36,9 @@ $factory->define(ModuleInstance::class, function(Faker $faker) {
             return factory(Logic::class)->create()->id;
         },
         'completion_condition_instance_id' => null,
-        'enabled' => true
+        'enabled' => true,
+        'user_id' => function() {
+            return factory(\BristolSU\ControlDB\Models\User::class)->create()->id();
+        }
     ];
 });

--- a/database/migrations/2020_02_20_125054_add_user_id_column_to_module_instances_table.php
+++ b/database/migrations/2020_02_20_125054_add_user_id_column_to_module_instances_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddUserIdColumnToModuleInstancesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     * 
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('module_instances', function (Blueprint $table) {
+            $table->unsignedBigInteger('user_id')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('module_instances', function (Blueprint $table) {
+            $table->dropColumn('user_id');
+        });
+    }
+}

--- a/database/migrations/2020_02_20_125226_add_user_id_column_to_activities_table.php
+++ b/database/migrations/2020_02_20_125226_add_user_id_column_to_activities_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddUserIdColumnToActivitiesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     * 
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('activities', function (Blueprint $table) {
+            $table->unsignedBigInteger('user_id')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('activities', function (Blueprint $table) {
+            $table->dropColumn('user_id');
+        });
+    }
+}

--- a/database/migrations/2020_02_20_125255_add_user_id_column_to_logics_table.php
+++ b/database/migrations/2020_02_20_125255_add_user_id_column_to_logics_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddUserIdColumnToLogicsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     * 
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('logics', function (Blueprint $table) {
+            $table->unsignedBigInteger('user_id')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('logics', function (Blueprint $table) {
+            $table->dropColumn('user_id');
+        });
+    }
+}

--- a/database/migrations/2020_02_20_125344_add_user_id_column_to_action_instances_table.php
+++ b/database/migrations/2020_02_20_125344_add_user_id_column_to_action_instances_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddUserIdColumnToActionInstancesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     * 
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('action_instances', function (Blueprint $table) {
+            $table->unsignedBigInteger('user_id')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('action_instances', function (Blueprint $table) {
+            $table->dropColumn('user_id');
+        });
+    }
+}

--- a/src/Action/ActionInstance.php
+++ b/src/Action/ActionInstance.php
@@ -3,8 +3,10 @@
 namespace BristolSU\Support\Action;
 
 use BristolSU\ControlDB\Contracts\Repositories\User;
+use BristolSU\Support\Authentication\Contracts\Authentication;
 use BristolSU\Support\ModuleInstance\ModuleInstance;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 
 /**
  * ActionInstance Model.
@@ -31,6 +33,23 @@ class ActionInstance extends Model
     protected $appends = [
         'event_fields', 'action_fields'
     ];
+
+    /**
+     * Initialise an Action Instance model.
+     *
+     * Save the ID of the current user on creation
+     *
+     * @param array $attributes
+     */
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+        self::creating(function($model) {
+            if($model->user_id === null && ($user = app(Authentication::class)->getUser()) !== null) {
+                $model->user_id = $user->id();
+            }
+        });
+    }
 
     /**
      * Action Instance field relationships
@@ -74,9 +93,13 @@ class ActionInstance extends Model
      * Get the user who created the action instance
      *
      * @return \BristolSU\ControlDB\Contracts\Models\User
+     * @throws \Exception If the user ID is null
      */
-    public function user()
+    public function user(): \BristolSU\ControlDB\Contracts\Models\User
     {
+        if($this->user_id === null) {
+            throw new \Exception(sprintf('Action Instance #%u is not owned by a user.', $this->id));
+        }
         return app(User::class)->getById($this->user_id);
     }
 }

--- a/src/Action/ActionInstance.php
+++ b/src/Action/ActionInstance.php
@@ -19,7 +19,7 @@ class ActionInstance extends Model
      * @var array
      */
     protected $fillable = [
-        'name', 'description', 'event', 'action', 'module_instance_id'  
+        'name', 'description', 'event', 'action', 'module_instance_id'
     ];
 
     /**

--- a/src/Action/ActionInstance.php
+++ b/src/Action/ActionInstance.php
@@ -2,6 +2,7 @@
 
 namespace BristolSU\Support\Action;
 
+use BristolSU\ControlDB\Contracts\Repositories\User;
 use BristolSU\Support\ModuleInstance\ModuleInstance;
 use Illuminate\Database\Eloquent\Model;
 
@@ -19,7 +20,7 @@ class ActionInstance extends Model
      * @var array
      */
     protected $fillable = [
-        'name', 'description', 'event', 'action', 'module_instance_id'
+        'name', 'description', 'event', 'action', 'module_instance_id', 'user_id'
     ];
 
     /**
@@ -68,5 +69,14 @@ class ActionInstance extends Model
     {
         return $this->belongsTo(ModuleInstance::class);
     }
-    
+
+    /**
+     * Get the user who created the action instance
+     *
+     * @return \BristolSU\ControlDB\Contracts\Models\User
+     */
+    public function user()
+    {
+        return app(User::class)->getById($this->user_id);
+    }
 }

--- a/src/Activity/Activity.php
+++ b/src/Activity/Activity.php
@@ -2,6 +2,7 @@
 
 namespace BristolSU\Support\Activity;
 
+use BristolSU\ControlDB\Contracts\Repositories\User;
 use BristolSU\Support\ActivityInstance\ActivityInstance;
 use BristolSU\Support\Logic\Logic;
 use BristolSU\Support\ModuleInstance\ModuleInstance;
@@ -30,7 +31,8 @@ class Activity extends Model
         'end_date',
         'slug',
         'type',
-        'enabled'
+        'enabled',
+        'user_id'
     ];
 
     /**
@@ -138,5 +140,15 @@ class Activity extends Model
     public function activityInstances()
     {
         return $this->hasMany(ActivityInstance::class);
+    }
+
+    /**
+     * Get the user who created the activity
+     *
+     * @return \BristolSU\ControlDB\Contracts\Models\User
+     */
+    public function user()
+    {
+        return app(User::class)->getById($this->user_id);
     }
 }

--- a/src/Logic/Logic.php
+++ b/src/Logic/Logic.php
@@ -2,6 +2,7 @@
 
 namespace BristolSU\Support\Logic;
 
+use BristolSU\ControlDB\Contracts\Repositories\User;
 use BristolSU\Support\Filters\FilterInstance;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
@@ -19,6 +20,7 @@ class Logic extends Model
     protected $fillable = [
         'name',
         'description',
+        'user_id'
     ];
 
     /**
@@ -112,5 +114,15 @@ class Logic extends Model
             return 'user';
         }
         return 'none';
+    }
+
+    /**
+     * Get the user who created the logic
+     *
+     * @return \BristolSU\ControlDB\Contracts\Models\User
+     */
+    public function user()
+    {
+        return app(User::class)->getById($this->user_id);
     }
 }

--- a/src/ModuleInstance/Contracts/ModuleInstance.php
+++ b/src/ModuleInstance/Contracts/ModuleInstance.php
@@ -4,6 +4,8 @@
 namespace BristolSU\Support\ModuleInstance\Contracts;
 
 
+use BristolSU\ControlDB\Contracts\Models\User;
+
 /**
  * Represents a module instance
  */
@@ -24,4 +26,10 @@ interface ModuleInstance
      */
     public function alias();
 
+    /**
+     * Get the user who created the module instance
+     * 
+     * @return User
+     */
+    public function user();
 }

--- a/src/ModuleInstance/ModuleInstance.php
+++ b/src/ModuleInstance/ModuleInstance.php
@@ -5,6 +5,7 @@ namespace BristolSU\Support\ModuleInstance;
 use BristolSU\ControlDB\Contracts\Repositories\User;
 use BristolSU\Support\Action\ActionInstance;
 use BristolSU\Support\Activity\Activity;
+use BristolSU\Support\Authentication\Contracts\Authentication;
 use BristolSU\Support\Completion\CompletionConditionInstance;
 use BristolSU\Support\Logic\Logic;
 use BristolSU\Support\ModuleInstance\Connection\ModuleInstanceService;
@@ -61,6 +62,9 @@ class ModuleInstance extends Model implements ModuleInstanceContract
         self::creating(function($model) {
             if ($model->slug === null) {
                 $model->slug = Str::slug($model->name);
+            }
+            if($model->user_id === null && ($user = app(Authentication::class)->getUser()) !== null) {
+                $model->user_id = $user->id();
             }
         });
     }
@@ -204,11 +208,15 @@ class ModuleInstance extends Model implements ModuleInstanceContract
 
     /**
      * Get the user who created the module instance
-     * 
+     *
      * @return \BristolSU\ControlDB\Contracts\Models\User
+     * @throws \Exception If the user ID is null
      */
-    public function user()
+    public function user(): \BristolSU\ControlDB\Contracts\Models\User
     {
+        if($this->user_id === null) {
+            throw new \Exception(sprintf('Module Instance #%u is not owned by a user.', $this->id));
+        }
         return app(User::class)->getById($this->user_id);
     }
 }

--- a/src/ModuleInstance/ModuleInstance.php
+++ b/src/ModuleInstance/ModuleInstance.php
@@ -2,6 +2,7 @@
 
 namespace BristolSU\Support\ModuleInstance;
 
+use BristolSU\ControlDB\Contracts\Repositories\User;
 use BristolSU\Support\Action\ActionInstance;
 use BristolSU\Support\Activity\Activity;
 use BristolSU\Support\Completion\CompletionConditionInstance;
@@ -36,7 +37,8 @@ class ModuleInstance extends Model implements ModuleInstanceContract
         'visible',
         'mandatory',
         'completion_condition_instance_id',
-        'enabled'
+        'enabled',
+        'user_id'
     ];
 
     /**
@@ -198,5 +200,15 @@ class ModuleInstance extends Model implements ModuleInstanceContract
     public function scopeEnabled(Builder $query)
     {
         return $query->where('enabled', true);
+    }
+
+    /**
+     * Get the user who created the module instance
+     * 
+     * @return \BristolSU\ControlDB\Contracts\Models\User
+     */
+    public function user()
+    {
+        return app(User::class)->getById($this->user_id);
     }
 }

--- a/tests/Action/ActionInstanceTest.php
+++ b/tests/Action/ActionInstanceTest.php
@@ -2,6 +2,7 @@
 
 namespace BristolSU\Support\Tests\Action;
 
+use BristolSU\ControlDB\Contracts\Repositories\User;
 use BristolSU\Support\Action\ActionInstance;
 use BristolSU\Support\Action\ActionInstanceField;
 use BristolSU\Support\Action\Contracts\Action;
@@ -64,6 +65,17 @@ class ActionInstanceTest extends TestCase
         $this->assertInstanceOf(ModuleInstance::class, $actionInstance->moduleInstance);
         $this->assertModelEquals($moduleInstance, $actionInstance->moduleInstance);
         
+    }
+    
+    /** @test */
+    public function actionInstance_has_a_user_id(){
+        $user = $this->newUser();
+        $userRepository = $this->prophesize(User::class);
+        $userRepository->getById($user->id())->shouldBeCalled()->willReturn($user);
+        $this->instance(User::class, $userRepository->reveal());
+        
+        $actionInstance = factory(ActionInstance::class)->create(['user_id' => $user->id()]);
+        $this->assertModelEquals($user, $actionInstance->user());
     }
 }
 

--- a/tests/Action/ActionInstanceTest.php
+++ b/tests/Action/ActionInstanceTest.php
@@ -7,6 +7,8 @@ use BristolSU\Support\Action\ActionInstance;
 use BristolSU\Support\Action\ActionInstanceField;
 use BristolSU\Support\Action\Contracts\Action;
 use BristolSU\Support\Action\Contracts\TriggerableEvent;
+use BristolSU\Support\Authentication\Contracts\Authentication;
+use BristolSU\Support\Logic\Logic;
 use BristolSU\Support\ModuleInstance\ModuleInstance;
 use BristolSU\Support\Tests\TestCase;
 
@@ -66,16 +68,53 @@ class ActionInstanceTest extends TestCase
         $this->assertModelEquals($moduleInstance, $actionInstance->moduleInstance);
         
     }
-    
+
     /** @test */
-    public function actionInstance_has_a_user_id(){
+    public function user_returns_a_user_with_the_correct_id(){
         $user = $this->newUser();
         $userRepository = $this->prophesize(User::class);
         $userRepository->getById($user->id())->shouldBeCalled()->willReturn($user);
         $this->instance(User::class, $userRepository->reveal());
-        
+
         $actionInstance = factory(ActionInstance::class)->create(['user_id' => $user->id()]);
+        $this->assertInstanceOf(\BristolSU\ControlDB\Models\User::class, $actionInstance->user());
         $this->assertModelEquals($user, $actionInstance->user());
+    }
+
+    /** @test */
+    public function user_throws_an_exception_if_user_id_is_null(){
+        $actionInstance = factory(ActionInstance::class)->create(['user_id' => null, 'id' => 2000]);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Action Instance #2000 is not owned by a user');
+
+        $actionInstance->user();
+    }
+
+    /** @test */
+    public function user_id_is_automatically_added_on_creation(){
+        $user = $this->newUser();
+        $authentication = $this->prophesize(Authentication::class);
+        $authentication->getUser()->shouldBeCalled()->willReturn($user);
+        $this->instance(Authentication::class, $authentication->reveal());
+
+        $logic = factory(Logic::class)->create();
+        $actionInstance = factory(ActionInstance::class)->create(['user_id' => null]);
+        
+        $this->assertNotNull($actionInstance->user_id);
+        $this->assertEquals($user->id(), $actionInstance->user_id);
+    }
+
+    /** @test */
+    public function user_id_is_not_overridden_if_given(){
+        $user = $this->newUser();
+
+        $logic = factory(Logic::class)->create();
+        $actionInstance = factory(ActionInstance::class)->create(['user_id' => $user->id()]);
+        
+
+        $this->assertNotNull($actionInstance->user_id);
+        $this->assertEquals($user->id(), $actionInstance->user_id);
     }
 }
 

--- a/tests/Activity/RepositoryTest.php
+++ b/tests/Activity/RepositoryTest.php
@@ -150,7 +150,7 @@ class RepositoryTest extends TestCase
     /** @test */
     public function getForAdministrator_passes_a_user_to_the_logic_tester(){
         $activity = factory(Activity::class)->create();
-        $user = $this->newUser(['id' => 1]);
+        $user = $this->newUser();
         $logicTester = $this->prophesize(LogicTester::class);
         $logicTester->evaluate(Argument::that(function($arg) use ($activity) {
             return $arg->id === $activity->adminLogic->id;
@@ -166,7 +166,7 @@ class RepositoryTest extends TestCase
     /** @test */
     public function getForAdministrator_passes_a_group_to_the_logic_tester(){
         $activity = factory(Activity::class)->create();
-        $group = $this->newGroup(['id' => 1]);
+        $group = $this->newGroup();
         $logicTester = $this->prophesize(LogicTester::class);
         $logicTester->evaluate(Argument::that(function($arg) use ($activity) {
             return $arg->id === $activity->adminLogic->id;
@@ -180,7 +180,7 @@ class RepositoryTest extends TestCase
     /** @test */
     public function getForAdministrator_passes_a_role_to_the_logic_tester(){
         $activity = factory(Activity::class)->create();
-        $role = $this->newRole(['id' => 1]);
+        $role = $this->newRole();
         $logicTester = $this->prophesize(LogicTester::class);
         $logicTester->evaluate(Argument::that(function($arg) use ($activity) {
             return $arg->id === $activity->adminLogic->id;
@@ -208,7 +208,7 @@ class RepositoryTest extends TestCase
     /** @test */
     public function getForParticipant_passes_a_user_to_the_logic_tester(){
         $activity = factory(Activity::class)->create();
-        $user = $this->newUser(['id' => 2]);
+        $user = $this->newUser();
         $logicTester = $this->prophesize(LogicTester::class);
         $logicTester->evaluate(Argument::that(function($arg) use ($activity) {
             return $arg->id === $activity->forLogic->id;
@@ -224,7 +224,7 @@ class RepositoryTest extends TestCase
     /** @test */
     public function getForParticipant_passes_a_group_to_the_logic_tester(){
         $activity = factory(Activity::class)->create();
-        $group = $this->newGroup(['id' => 1]);
+        $group = $this->newGroup();
         $logicTester = $this->prophesize(LogicTester::class);
         $logicTester->evaluate(Argument::that(function($arg) use ($activity) {
             return $arg->id === $activity->forLogic->id;
@@ -238,7 +238,7 @@ class RepositoryTest extends TestCase
     /** @test */
     public function getForParticipant_passes_a_role_to_the_logic_tester(){
         $activity = factory(Activity::class)->create();
-        $role = $this->newRole(['id' => 1]);
+        $role = $this->newRole();
         $logicTester = $this->prophesize(LogicTester::class);
         $logicTester->evaluate(Argument::that(function($arg) use ($activity) {
             return $arg->id === $activity->forLogic->id;

--- a/tests/ActivityInstance/ActivityInstanceTest.php
+++ b/tests/ActivityInstance/ActivityInstanceTest.php
@@ -82,12 +82,12 @@ class ActivityInstanceTest extends TestCase
 
     /** @test */
     public function getParticipantAttribute_returns_a_user_if_resource_type_is_a_user(){
-        $user = $this->newUser(['id' => 3]);
+        $user = $this->newUser();
         $userRepository = $this->prophesize(UserRepository::class);
-        $userRepository->getById(3)->shouldBeCalledTimes(3)->willReturn($user);
+        $userRepository->getById($user->id())->shouldBeCalledTimes(3)->willReturn($user);
         $this->app->instance(UserRepository::class, $userRepository->reveal());
         
-        $activityInstance = factory(ActivityInstance::class)->create(['resource_type' => 'user', 'resource_id' => 3]);
+        $activityInstance = factory(ActivityInstance::class)->create(['resource_type' => 'user', 'resource_id' => $user->id()]);
         $this->assertEquals($user, $activityInstance->getParticipantAttribute());
         $this->assertEquals($user, $activityInstance->participant);
         $this->assertEquals($user, $activityInstance->participant());
@@ -95,12 +95,12 @@ class ActivityInstanceTest extends TestCase
 
     /** @test */
     public function getParticipantAttribute_returns_a_group_if_resource_type_is_a_group(){
-        $group = $this->newGroup(['id' => 3]);
+        $group = $this->newGroup();
         $groupRepository = $this->prophesize(GroupRepository::class);
-        $groupRepository->getById(3)->shouldBeCalledTimes(3)->willReturn($group);
+        $groupRepository->getById($group->id())->shouldBeCalledTimes(3)->willReturn($group);
         $this->app->instance(GroupRepository::class, $groupRepository->reveal());
 
-        $activityInstance = factory(ActivityInstance::class)->create(['resource_type' => 'group', 'resource_id' => 3]);
+        $activityInstance = factory(ActivityInstance::class)->create(['resource_type' => 'group', 'resource_id' => $group->id()]);
         $this->assertEquals($group, $activityInstance->getParticipantAttribute());
         $this->assertEquals($group, $activityInstance->participant);
         $this->assertEquals($group, $activityInstance->participant());
@@ -108,12 +108,12 @@ class ActivityInstanceTest extends TestCase
 
     /** @test */
     public function getParticipantAttribute_returns_a_role_if_resource_type_is_a_role(){
-        $role = $this->newRole(['id' => 3]);
+        $role = $this->newRole();
         $roleRepository = $this->prophesize(RoleRepository::class);
-        $roleRepository->getById(3)->shouldBeCalledTimes(3)->willReturn($role);
+        $roleRepository->getById($role->id())->shouldBeCalledTimes(3)->willReturn($role);
         $this->app->instance(RoleRepository::class, $roleRepository->reveal());
 
-        $activityInstance = factory(ActivityInstance::class)->create(['resource_type' => 'role', 'resource_id' => 3]);
+        $activityInstance = factory(ActivityInstance::class)->create(['resource_type' => 'role', 'resource_id' => $role->id()]);
         $this->assertEquals($role, $activityInstance->getParticipantAttribute());
         $this->assertEquals($role, $activityInstance->participant);
         $this->assertEquals($role, $activityInstance->participant());

--- a/tests/Authentication/AuthenticationResourceIdGeneratorTest.php
+++ b/tests/Authentication/AuthenticationResourceIdGeneratorTest.php
@@ -16,31 +16,31 @@ class AuthenticationResourceIdGeneratorTest extends TestCase
     /** @test */
     public function fromString_returns_the_user_id_if_user_given(){
         $authentication = $this->prophesize(Authentication::class);
-        $user = $this->newUser(['id' => 1]);
+        $user = $this->newUser();
         $authentication->getUser()->shouldBeCalled()->willReturn($user);
 
         $idGenerator = new AuthenticationResourceIdGenerator($authentication->reveal());
-        $this->assertEquals(1, $idGenerator->fromString('user'));
+        $this->assertEquals($user->id(), $idGenerator->fromString('user'));
     }
 
     /** @test */
     public function fromString_returns_the_group_id_if_group_given(){
         $authentication = $this->prophesize(Authentication::class);
-        $group = $this->newGroup(['id' => 1]);
+        $group = $this->newGroup();
         $authentication->getGroup()->shouldBeCalled()->willReturn($group);
 
         $idGenerator = new AuthenticationResourceIdGenerator($authentication->reveal());
-        $this->assertEquals(1, $idGenerator->fromString('group'));
+        $this->assertEquals($group->id(), $idGenerator->fromString('group'));
     }
 
     /** @test */
     public function fromString_returns_the_role_id_if_role_given(){
         $authentication = $this->prophesize(Authentication::class);
-        $role = $this->newRole(['id' => 1]);
+        $role = $this->newRole();
         $authentication->getRole()->shouldBeCalled()->willReturn($role);
 
         $idGenerator = new AuthenticationResourceIdGenerator($authentication->reveal());
-        $this->assertEquals(1, $idGenerator->fromString('role'));
+        $this->assertEquals($role->id(), $idGenerator->fromString('role'));
     }
 
     /** @test */

--- a/tests/Authentication/WebSessionAuthenticationTest.php
+++ b/tests/Authentication/WebSessionAuthenticationTest.php
@@ -29,8 +29,8 @@ class WebSessionAuthenticationTest extends TestCase
 
     /** @test */
     public function get_group_returns_a_group_given_by_a_role_if_role_given(){
-        $group = $this->newGroup(['id' => 2]);
-        $role = $this->newRole(['id' => 1, 'group_id' => 2]);
+        $group = $this->newGroup();
+        $role = $this->newRole(['group_id' => $group->id()]);
         $this->beRole($role);
 
         $authentication = resolve(WebSessionAuthentication::class);
@@ -50,11 +50,11 @@ class WebSessionAuthenticationTest extends TestCase
     /** @test */
     public function get_role_gets_role_if_logged_in()
     {
-        $role = $this->newRole(['id' => 2]);
+        $role = $this->newRole();
         $this->beRole($role);
         
         $authentication = resolve(WebSessionAuthentication::class);
-        $this->assertEquals(2, $authentication->getRole()->id);
+        $this->assertEquals($role->id(), $authentication->getRole()->id);
     }
 
     /** @test */
@@ -68,10 +68,10 @@ class WebSessionAuthenticationTest extends TestCase
     /** @test */
     public function get_user_returns_a_user_if_logged_into_a_user()
     {
-        $user = $this->newUser(['id' => 1]);
+        $user = $this->newUser();
         $this->beUser($user);
         $authentication = resolve(WebSessionAuthentication::class);
-        $this->assertEquals($user->id, $authentication->getUser()->id());
+        $this->assertEquals($user->id(), $authentication->getUser()->id());
     }
 
     /** @test */
@@ -85,7 +85,7 @@ class WebSessionAuthenticationTest extends TestCase
     /** @test */
     public function set_user_sets_the_user()
     {
-        $user = $this->newUser(['id' => 1]);
+        $user = $this->newUser();
         $authentication = resolve(WebSessionAuthentication::class);
         $authentication->setUser($user);
         $this->assertTrue(Session::has('user_id'));
@@ -95,7 +95,7 @@ class WebSessionAuthenticationTest extends TestCase
     /** @test */
     public function set_group_sets_the_group()
     {
-        $group = $this->newGroup(['id' => 1]);
+        $group = $this->newGroup();
         $authentication = resolve(WebSessionAuthentication::class);
         $authentication->setGroup($group);
         $this->assertTrue(Session::has('group_id'));
@@ -105,7 +105,7 @@ class WebSessionAuthenticationTest extends TestCase
     /** @test */
     public function set_role_sets_the_role()
     {
-        $role = $this->newRole(['id' => 1]);
+        $role = $this->newRole();
         $authentication = resolve(WebSessionAuthentication::class);
         $authentication->setRole($role);
         $this->assertTrue(Session::has('role_id'));

--- a/tests/Authorization/Middleware/CheckActivityForTest.php
+++ b/tests/Authorization/Middleware/CheckActivityForTest.php
@@ -24,9 +24,9 @@ class CheckActivityForTest extends TestCase
         $this->expectException(ActivityRequiresParticipant::class);
         
         $authentication = $this->prophesize(Authentication::class);
-        $user = $this->newUser(['id' => 1]);
-        $group = $this->newGroup(['id' => 5]);
-        $role = $this->newRole(['id' => 10]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
         $authentication->getUser()->willReturn($user);
         $authentication->getGroup()->willReturn($group);
         $authentication->getRole()->willReturn($role);
@@ -50,9 +50,9 @@ class CheckActivityForTest extends TestCase
         $this->expectException(ActivityRequiresParticipant::class);
         
         $authentication = $this->prophesize(Authentication::class);
-        $user = $this->newUser(['id' => 1]);
-        $group = $this->newGroup(['id' => 5]);
-        $role = $this->newRole(['id' => 10]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
         $authentication->getUser()->willReturn($user);
         $authentication->getGroup()->willReturn($group);
         $authentication->getRole()->willReturn($role);
@@ -76,9 +76,9 @@ class CheckActivityForTest extends TestCase
         $this->expectException(ActivityRequiresParticipant::class);
         
         $authentication = $this->prophesize(Authentication::class);
-        $user = $this->newUser(['id' => 1]);
-        $group = $this->newGroup(['id' => 2]);
-        $role = $this->newRole(['id' => 3]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
         $authentication->getUser()->willReturn($user);
         $authentication->getGroup()->willReturn($group);
         $authentication->getRole()->willReturn($role);
@@ -104,9 +104,9 @@ class CheckActivityForTest extends TestCase
         ]);
         
         $authentication = $this->prophesize(Authentication::class);
-        $user = $this->newUser(['id' => 1]);
-        $group = $this->newGroup(['id' => 5]);
-        $role = $this->newRole(['id' => 10]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
         $authentication->getUser()->willReturn($user);
         $authentication->getGroup()->willReturn($group);
         $authentication->getRole()->willReturn($role);

--- a/tests/Authorization/Middleware/CheckAdminActivityForTest.php
+++ b/tests/Authorization/Middleware/CheckAdminActivityForTest.php
@@ -28,9 +28,9 @@ class CheckAdminActivityForTest extends TestCase
         $request->route('activity_slug')->willReturn($activity);
         $authentication = $this->prophesize(Authentication::class);
 
-        $user = $this->newUser(['id' => 1]);
-        $group = $this->newGroup(['id' => 5]);
-        $role = $this->newRole(['id' => 10]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
         $authentication->getUser()->willReturn($user);
         $authentication->getGroup()->willReturn($group);
         $authentication->getRole()->willReturn($role);
@@ -50,9 +50,9 @@ class CheckAdminActivityForTest extends TestCase
         $request->route('test_callback_is_called')->shouldBeCalled()->willReturn(true);
 
         $authentication = $this->prophesize(Authentication::class);
-        $user = $this->newUser(['id' => 1]);
-        $group = $this->newGroup(['id' => 5]);
-        $role = $this->newRole(['id' => 10]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
         $authentication->getUser()->willReturn($user);
         $authentication->getGroup()->willReturn($group);
         $authentication->getRole()->willReturn($role);

--- a/tests/Authorization/Middleware/CheckLoggedIntoActivityForTypeTest.php
+++ b/tests/Authorization/Middleware/CheckLoggedIntoActivityForTypeTest.php
@@ -71,9 +71,9 @@ class CheckLoggedIntoActivityForTypeTest extends TestCase
             'activity_for' => 'user'
         ]);
         $authentication = $this->prophesize(Authentication::class);
-        $authentication->getUser()->willReturn($this->newUser(['id' => 1]));
-        $authentication->getGroup()->willReturn($this->newGroup(['id' => 1]));
-        $authentication->getRole()->willReturn($this->newRole(['id' => 1]));
+        $authentication->getUser()->willReturn($this->newUser());
+        $authentication->getGroup()->willReturn($this->newGroup());
+        $authentication->getRole()->willReturn($this->newRole());
 
         $request = $this->prophesize(Request::class);
         $request->route('activity_slug')->willReturn($activity);

--- a/tests/Authorization/Middleware/CheckModuleInstanceActiveTest.php
+++ b/tests/Authorization/Middleware/CheckModuleInstanceActiveTest.php
@@ -26,9 +26,9 @@ class CheckModuleInstanceActiveTest extends TestCase
         $request->route('module_instance_slug')->willReturn($moduleInstance);
         
         $authentication = $this->prophesize(Authentication::class);
-        $user = $this->newUser(['id' => 1]);
-        $group = $this->newGroup(['id' => 5]);
-        $role = $this->newRole(['id' => 10]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
         $authentication->getUser()->willReturn($user);
         $authentication->getGroup()->willReturn($group);
         $authentication->getRole()->willReturn($role);
@@ -49,9 +49,9 @@ class CheckModuleInstanceActiveTest extends TestCase
         $request->route('test_callback_is_called')->shouldBeCalled()->willReturn(true);
 
         $authentication = $this->prophesize(Authentication::class);
-        $user = $this->newUser(['id' => 1]);
-        $group = $this->newGroup(['id' => 5]);
-        $role = $this->newRole(['id' => 10]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
         $authentication->getUser()->willReturn($user);
         $authentication->getGroup()->willReturn($group);
         $authentication->getRole()->willReturn($role);

--- a/tests/Filters/CachedFilterTesterDecoratorTest.php
+++ b/tests/Filters/CachedFilterTesterDecoratorTest.php
@@ -17,7 +17,7 @@ class CachedFilterTesterDecoratorTest extends TestCase
     /** @test */
     public function it_caches_and_returns_the_result_of_evaluate(){
         $filterInstance = factory(FilterInstance::class)->create();
-        $model = $this->newUser(['id' => 1]);
+        $model = $this->newUser();
 
         $realTester = $this->prophesize(FilterTester::class);
         $realTester->evaluate(Argument::that(function($arg) use ($filterInstance) {
@@ -37,7 +37,7 @@ class CachedFilterTesterDecoratorTest extends TestCase
     public function the_cache_key_changes_if_filter_instance_changes(){
         $filterInstance1 = factory(FilterInstance::class)->create();
         $filterInstance2 = factory(FilterInstance::class)->create();
-        $model = $this->newUser(['id' => 1]);
+        $model = $this->newUser();
         
         $realTester = $this->prophesize(FilterTester::class);
         $realTester->evaluate(Argument::that(function($arg) use ($filterInstance1) {
@@ -61,8 +61,8 @@ class CachedFilterTesterDecoratorTest extends TestCase
     /** @test */
     public function the_cache_key_changes_if_model_id_changes(){
         $filterInstance = factory(FilterInstance::class)->create();
-        $model1 = $this->newUser(['id' => 1]);
-        $model2 = $this->newUser(['id' => 2]);
+        $model1 = $this->newUser();
+        $model2 = $this->newUser();
 
         $realTester = $this->prophesize(FilterTester::class);
         $realTester->evaluate(Argument::that(function($arg) use ($filterInstance) {
@@ -86,8 +86,8 @@ class CachedFilterTesterDecoratorTest extends TestCase
     /** @test */
     public function the_cache_key_changes_if_model_type_changes(){
         $filterInstance = factory(FilterInstance::class)->create();
-        $model1 = $this->newUser(['id' => 1]);
-        $model2 = $this->newGroup(['id' => 1]);
+        $model1 = $this->newUser();
+        $model2 = $this->newGroup();
 
         $realTester = $this->prophesize(FilterTester::class);
         $realTester->evaluate(Argument::that(function($arg) use ($filterInstance) {

--- a/tests/Filters/Commands/CacheFiltersTest.php
+++ b/tests/Filters/Commands/CacheFiltersTest.php
@@ -31,9 +31,9 @@ class CacheFiltersTest extends TestCase
         }
 
         $users = [
-            $this->newUser(['id' => 1]),
-            $this->newUser(['id' => 2]),
-            $this->newUser(['id' => 3]),
+            $this->newUser(),
+            $this->newUser(),
+            $this->newUser(),
         ];
 
         $filterInstanceRepository = $this->prophesize(FilterInstanceRepository::class);
@@ -75,9 +75,9 @@ class CacheFiltersTest extends TestCase
         }
 
         $groups = [
-            $this->newGroup(['id' => 1]),
-            $this->newGroup(['id' => 2]),
-            $this->newGroup(['id' => 3]),
+            $this->newGroup(),
+            $this->newGroup(),
+            $this->newGroup(),
         ];
 
         $filterInstanceRepository = $this->prophesize(FilterInstanceRepository::class);
@@ -119,9 +119,9 @@ class CacheFiltersTest extends TestCase
         }
 
         $roles = [
-            $this->newRole(['id' => 1]),
-            $this->newRole(['id' => 2]),
-            $this->newRole(['id' => 3]),
+            $this->newRole(),
+            $this->newRole(),
+            $this->newRole(),
         ];
 
         $filterInstanceRepository = $this->prophesize(FilterInstanceRepository::class);

--- a/tests/Filters/Contracts/Filters/GroupFilterTest.php
+++ b/tests/Filters/Contracts/Filters/GroupFilterTest.php
@@ -14,7 +14,7 @@ class GroupFilterTest extends TestCase
     /** @test */
     public function getModel_returns_the_set_model(){
         $filter = new DummyGroupFilter();
-        $group = $this->newGroup(['id' => 1]);
+        $group = $this->newGroup();
         $filter->setModel($group);
         $this->assertEquals($group, $filter->model());
     }
@@ -22,7 +22,7 @@ class GroupFilterTest extends TestCase
     /** @test */
     public function hasModel_returns_true_if_the_group_is_set(){
         $filter = new DummyGroupFilter();
-        $dummyGroup = $this->newGroup(['id' => 1]);
+        $dummyGroup = $this->newGroup();
         $filter->setModel($dummyGroup);
 
         $this->assertTrue($filter->hasModel());
@@ -47,7 +47,7 @@ class GroupFilterTest extends TestCase
     /** @test */
     public function group_returns_the_group(){
         $filter = new DummyGroupFilter();
-        $group = $this->newGroup(['id' => 1]);
+        $group = $this->newGroup();
         $filter->setModel($group);
         $this->assertEquals($group, $filter->group());
     }

--- a/tests/Filters/Contracts/Filters/RoleFilterTest.php
+++ b/tests/Filters/Contracts/Filters/RoleFilterTest.php
@@ -13,7 +13,7 @@ class RoleFilterTest extends TestCase
     /** @test */
     public function getModel_returns_the_set_model(){
         $filter = new DummyRoleFilter();
-        $role = $this->newRole(['id' => 1]);
+        $role = $this->newRole();
         $filter->setModel($role);
         $this->assertEquals($role, $filter->model());
     }
@@ -21,7 +21,7 @@ class RoleFilterTest extends TestCase
     /** @test */
     public function hasModel_returns_true_if_the_role_is_set(){
         $filter = new DummyRoleFilter();
-        $dummyRole = $this->newRole(['id' => 1]);
+        $dummyRole = $this->newRole();
         $filter->setModel($dummyRole);
 
         $this->assertTrue($filter->hasModel());
@@ -46,7 +46,7 @@ class RoleFilterTest extends TestCase
     /** @test */
     public function role_returns_the_role(){
         $filter = new DummyRoleFilter();
-        $role = $this->newRole(['id' => 1]);
+        $role = $this->newRole();
         $filter->setModel($role);
         $this->assertEquals($role, $filter->role());
     }

--- a/tests/Filters/Contracts/Filters/UserFilterTest.php
+++ b/tests/Filters/Contracts/Filters/UserFilterTest.php
@@ -13,7 +13,7 @@ class UserFilterTest extends TestCase
     /** @test */
     public function getModel_returns_the_set_model(){
         $filter = new DummyUserFilter();
-        $user = $this->newUser(['id' => 1]);
+        $user = $this->newUser();
         $filter->setModel($user);
         $this->assertEquals($user, $filter->model());
     }
@@ -21,7 +21,7 @@ class UserFilterTest extends TestCase
     /** @test */
     public function hasModel_returns_true_if_the_user_is_set(){
         $filter = new DummyUserFilter();
-        $dummyUser = $this->newUser(['id' => 1]);
+        $dummyUser = $this->newUser();
         $filter->setModel($dummyUser);
 
         $this->assertTrue($filter->hasModel());
@@ -46,7 +46,7 @@ class UserFilterTest extends TestCase
     /** @test */
     public function user_returns_the_user(){
         $filter = new DummyUserFilter();
-        $user = $this->newUser(['id' => 1]);
+        $user = $this->newUser();
         $filter->setModel($user);
         $this->assertEquals($user, $filter->user());
     }

--- a/tests/Filters/Filters/Role/RoleHasPositionTest.php
+++ b/tests/Filters/Filters/Role/RoleHasPositionTest.php
@@ -51,7 +51,7 @@ class RoleHasPositionTest extends TestCase
     /** @test */
     public function it_evaluates_to_false_if_role_does_not_have_position(){
         $roleHasPositionFilter = new RoleHasPosition($this->prophesize(PositionRepository::class)->reveal());
-        $role = $this->newRole(['id' => 1, 'position_id' => 2]);
+        $role = $this->newRole(['position_id' => 2]);
         $roleHasPositionFilter->setModel($role);
         $this->assertFalse($roleHasPositionFilter->evaluate(['position' => '1']));
     }

--- a/tests/Filters/Filters/User/UserEmailIsTest.php
+++ b/tests/Filters/Filters/User/UserEmailIsTest.php
@@ -25,7 +25,7 @@ class UserEmailIsTest extends TestCase
     /** @test */
     public function evaluate_returns_true_if_a_user_email_is_equal_to_the_settings(){
         $dataUser = factory(DataUser::class)->create(['id' => 1, 'email' => 'tobyt@example.com']);
-        $user = $this->newUser(['id' => 10, 'data_provider_id' => 1]);
+        $user = $this->newUser(['data_provider_id' => 1]);
         $dataUserRepository = $this->prophesize(DataUserRepository::class);
         $dataUserRepository->getById(1)->shouldBeCalled()->willReturn($dataUser);
         $this->app->instance(DataUserRepository::class, $dataUserRepository->reveal());
@@ -38,7 +38,7 @@ class UserEmailIsTest extends TestCase
     /** @test */
     public function evaluate_returns_false_if_a_user_email_is_not_equal_to_the_settings(){
         $dataUser = factory(DataUser::class)->create(['id' => 1, 'email' => 'tobyt@example.com']);
-        $user = $this->newUser(['id' => 10, 'data_provider_id' => 1]);
+        $user = $this->newUser(['data_provider_id' => 1]);
         $dataUserRepository = $this->prophesize(DataUserRepository::class);
         $dataUserRepository->getById(1)->shouldBeCalled()->willReturn($dataUser);
         $this->app->instance(DataUserRepository::class, $dataUserRepository->reveal());
@@ -50,7 +50,7 @@ class UserEmailIsTest extends TestCase
 
     /** @test */
     public function evaluate_returns_false_if_dataRepository_throws_exception(){
-        $user = $this->newUser(['id' => 10, 'data_provider_id' => 1]);
+        $user = $this->newUser(['data_provider_id' => 1]);
         $dataUserRepository = $this->prophesize(DataUserRepository::class);
         $dataUserRepository->getById(1)->shouldBeCalled()->willThrow(new \Exception());
         $this->app->instance(DataUserRepository::class, $dataUserRepository->reveal());

--- a/tests/Filters/Jobs/CacheFilterTest.php
+++ b/tests/Filters/Jobs/CacheFilterTest.php
@@ -15,7 +15,7 @@ class CacheFilterTest extends TestCase
 
     /** @test */
     public function it_evaluates_the_given_filter_with_the_given_model(){
-        $model = $this->newUser(['id' => 1]);
+        $model = $this->newUser();
         $filterInstance = factory(FilterInstance::class)->create([
             'alias' => 'alias1',
             'settings' => ['key1' => 'val1', 'key2' => 'val2']

--- a/tests/Logic/Audience/AudienceMemberFactoryTest.php
+++ b/tests/Logic/Audience/AudienceMemberFactoryTest.php
@@ -12,7 +12,7 @@ class  AudienceMemberFactoryTest extends TestCase
     
     /** @test */
     public function fromUser_creates_an_audience_member_from_a_given_user(){
-        $user = $this->newUser(['id' => 1]);
+        $user = $this->newUser();
         $factory = new AudienceMemberFactory;
         $audienceMember = $factory->fromUser($user);
 

--- a/tests/Logic/Audience/AudienceMemberTest.php
+++ b/tests/Logic/Audience/AudienceMemberTest.php
@@ -16,9 +16,9 @@ class AudienceMemberTest extends TestCase
 
     /** @test */
     public function groups_loads_the_users_groups_if_not_already_loaded(){
-        $user = $this->newUser(['id' => 1]);
-        $group1 = $this->newGroup(['id' => 2]);
-        $group2 = $this->newGroup(['id' => 3]);
+        $user = $this->newUser();
+        $group1 = $this->newGroup();
+        $group2 = $this->newGroup();
         $groups = collect([$group1, $group2]);
 
         $user->addGroup($group1);
@@ -33,9 +33,9 @@ class AudienceMemberTest extends TestCase
     
     /** @test */
     public function roles_loads_the_users_roles_if_not_already_loaded(){
-        $user = $this->newUser(['id' => 1]);
-        $role1 = $this->newRole(['id' => 2]);
-        $role2 = $this->newRole(['id' => 3]);
+        $user = $this->newUser();
+        $role1 = $this->newRole();
+        $role2 = $this->newRole();
         $roles = collect([$role1, $role2]);
 
         $user->addRole($role1);
@@ -50,7 +50,7 @@ class AudienceMemberTest extends TestCase
     
     /** @test */
     public function user_returns_the_user(){
-        $user = $this->newUser(['id' => 1]);
+        $user = $this->newUser();
 
         $audienceMember = new AudienceMember($user);
         $this->assertEquals($user, $audienceMember->user());
@@ -59,7 +59,7 @@ class AudienceMemberTest extends TestCase
     /** @test */
     public function filterForLogic_evaluates_the_user(){
         $logic = factory(Logic::class)->create();
-        $user = $this->newUser(['id' => 1]);
+        $user = $this->newUser();
         
         $audienceMember = new AudienceMember($user);
         
@@ -79,9 +79,9 @@ class AudienceMemberTest extends TestCase
     /** @test */
     public function filterForLogic_evaluates_each_group(){
         $logic = factory(Logic::class)->create();
-        $user = $this->newUser(['id' => 1]);
-        $group1 = $this->newGroup(['id' => 2]);
-        $group2 = $this->newGroup(['id' => 3]);
+        $user = $this->newUser();
+        $group1 = $this->newGroup();
+        $group2 = $this->newGroup();
         $groups = collect([$group1, $group2]);
 
         $user->addGroup($group1);
@@ -106,9 +106,9 @@ class AudienceMemberTest extends TestCase
     /** @test */
     public function filterForLogic_evaluates_each_role(){
         $logic = factory(Logic::class)->create();
-        $user = $this->newUser(['id' => 1]);
-        $role1 = $this->newRole(['id' => 4]);
-        $role2 = $this->newRole(['id' => 5]);
+        $user = $this->newUser();
+        $role1 = $this->newRole();
+        $role2 = $this->newRole();
         $roles = collect([$role1, $role2]);
 
         $user->addRole($role1);
@@ -134,7 +134,7 @@ class AudienceMemberTest extends TestCase
     /** @test */
     public function hasAudience_returns_true_if_a_user_can_act_as_themselves(){
         $logic = factory(Logic::class)->create();
-        $user = $this->newUser(['id' => 1]);
+        $user = $this->newUser();
 
         $audienceMember = new AudienceMember($user);
 
@@ -154,9 +154,9 @@ class AudienceMemberTest extends TestCase
     /** @test */
     public function hasAudience_returns_true_if_a_user_has_groups(){
         $logic = factory(Logic::class)->create();
-        $user = $this->newUser(['id' => 1]);
-        $group1 = $this->newGroup(['id' => 2]);
-        $group2 = $this->newGroup(['id' => 3]);
+        $user = $this->newUser();
+        $group1 = $this->newGroup();
+        $group2 = $this->newGroup();
 
         $user->addGroup($group1);
         $user->addGroup($group2);
@@ -181,9 +181,9 @@ class AudienceMemberTest extends TestCase
     /** @test */
     public function hasAudience_returns_true_if_a_user_has_roles(){
         $logic = factory(Logic::class)->create();
-        $user = $this->newUser(['id' => 1]);
-        $role1 = $this->newRole(['id' => 4]);
-        $role2 = $this->newRole(['id' => 5]);
+        $user = $this->newUser();
+        $role1 = $this->newRole();
+        $role2 = $this->newRole();
         $roles = collect([$role1, $role2]);
 
         $user->addRole($role1);
@@ -209,11 +209,11 @@ class AudienceMemberTest extends TestCase
     /** @test */
     public function hasAudience_returns_false_if_a_user_cannot_be_themselves_or_any_group_or_role(){
         $logic = factory(Logic::class)->create();
-        $user = $this->newUser(['id' => 1]);
-        $group1 = $this->newGroup(['id' => 2]);
-        $group2 = $this->newGroup(['id' => 3]);
-        $role1 = $this->newRole(['id' => 4]);
-        $role2 = $this->newRole(['id' => 5]);
+        $user = $this->newUser();
+        $group1 = $this->newGroup();
+        $group2 = $this->newGroup();
+        $role1 = $this->newRole();
+        $role2 = $this->newRole();
         $groups = collect([$group1, $group2]);
         $roles = collect([$role1, $role2]);
 
@@ -240,11 +240,11 @@ class AudienceMemberTest extends TestCase
     /** @test */
     public function toArray_toJson_and_toString_returns_attributes(){
         $logic = factory(Logic::class)->create();
-        $user = $this->newUser(['id' => 1]);
-        $group1 = $this->newGroup(['id' => 2]);
-        $group2 = $this->newGroup(['id' => 3]);
-        $role1 = $this->newRole(['id' => 4]);
-        $role2 = $this->newRole(['id' => 5]);
+        $user = $this->newUser();
+        $group1 = $this->newGroup();
+        $group2 = $this->newGroup();
+        $role1 = $this->newRole();
+        $role2 = $this->newRole();
         $groups = collect([$group1, $group2]);
         $roles = collect([$role1, $role2]);
 
@@ -275,7 +275,7 @@ class AudienceMemberTest extends TestCase
     
     /** @test */
     public function canBeUser_defaults_to_true(){
-        $user = $this->newUser(['id' => 1]);
+        $user = $this->newUser();
         $audienceMember = new AudienceMember($user);
         $this->assertTrue($audienceMember->canBeUser());
     }

--- a/tests/Logic/Audience/LogicAudienceTest.php
+++ b/tests/Logic/Audience/LogicAudienceTest.php
@@ -19,9 +19,9 @@ class LogicAudienceTest extends TestCase
     public function it_creates_an_audience_member_for_each_user(){
         $logic = factory(Logic::class)->create();
         
-        $user1 = $this->newUser(['id' => 1]);
-        $user2 = $this->newUser(['id' => 2]);
-        $user3 = $this->newUser(['id' => 3]);
+        $user1 = $this->newUser();
+        $user2 = $this->newUser();
+        $user3 = $this->newUser();
         $audienceMember1 = $this->prophesize(AudienceMember::class);
         $audienceMember2 = $this->prophesize(AudienceMember::class);
         $audienceMember3 = $this->prophesize(AudienceMember::class);
@@ -43,9 +43,9 @@ class LogicAudienceTest extends TestCase
     public function it_calls_filterForLogic_on_each_audience_member(){
         $logic = factory(Logic::class)->create();
 
-        $user1 = $this->newUser(['id' => 1]);
-        $user2 = $this->newUser(['id' => 2]);
-        $user3 = $this->newUser(['id' => 3]);
+        $user1 = $this->newUser();
+        $user2 = $this->newUser();
+        $user3 = $this->newUser();
         $audienceMember1 = $this->prophesize(AudienceMember::class);
         $audienceMember2 = $this->prophesize(AudienceMember::class);
         $audienceMember3 = $this->prophesize(AudienceMember::class);
@@ -80,9 +80,9 @@ class LogicAudienceTest extends TestCase
     public function it_calls_hasAudience_on_each_audience_member_and_returns_them_if_true(){
         $logic = factory(Logic::class)->create();
 
-        $user1 = $this->newUser(['id' => 1]);
-        $user2 = $this->newUser(['id' => 2]);
-        $user3 = $this->newUser(['id' => 3]);
+        $user1 = $this->newUser();
+        $user2 = $this->newUser();
+        $user3 = $this->newUser();
         $audienceMember1 = $this->prophesize(AudienceMember::class);
         $audienceMember2 = $this->prophesize(AudienceMember::class);
         $audienceMember3 = $this->prophesize(AudienceMember::class);
@@ -117,9 +117,9 @@ class LogicAudienceTest extends TestCase
     public function it_returns_an_empty_array_if_no_audience_found(){
         $logic = factory(Logic::class)->create();
 
-        $user1 = $this->newUser(['id' => 1]);
-        $user2 = $this->newUser(['id' => 2]);
-        $user3 = $this->newUser(['id' => 3]);
+        $user1 = $this->newUser();
+        $user2 = $this->newUser();
+        $user3 = $this->newUser();
         $audienceMember1 = $this->prophesize(AudienceMember::class);
         $audienceMember2 = $this->prophesize(AudienceMember::class);
         $audienceMember3 = $this->prophesize(AudienceMember::class);

--- a/tests/Logic/LogicTesterTest.php
+++ b/tests/Logic/LogicTesterTest.php
@@ -47,9 +47,9 @@ class LogicTesterTest extends TestCase
         $this->filterRepository = $this->prophesize(FilterRepository::class);
         $this->instance(FilterTester::class, $this->filterTester->reveal());
         $this->instance(FilterRepository::class, $this->filterRepository->reveal());
-        $this->fakeUser = $this->newUser(['id' => 1]);
-        $this->fakeGroup = $this->newGroup(['id' => 2]);
-        $this->fakeRole = $this->newRole(['id' => 3]);
+        $this->fakeUser = $this->newUser();
+        $this->fakeGroup = $this->newGroup();
+        $this->fakeRole = $this->newRole();
     }
 
     public function createFilter($logicId, $type, $evaluated, $filterType = 'user')

--- a/tests/Logic/Specification/FilterFalseSpecificationTest.php
+++ b/tests/Logic/Specification/FilterFalseSpecificationTest.php
@@ -15,9 +15,9 @@ class FilterFalseSpecificationTest extends TestCase
 
     /** @test */
     public function isSatisfied_returns_true_if_filter_false_when_a_user_filter_is_given(){
-        $user = $this->newUser(['id' => 1]);
-        $group = $this->newGroup(['id' => 2]);
-        $role = $this->newRole(['id' => 3]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
         
         $filter = $this->prophesize(FilterInstance::class);
         $filter->for()->shouldBeCalled()->willReturn('user');
@@ -35,9 +35,9 @@ class FilterFalseSpecificationTest extends TestCase
 
     /** @test */
     public function isSatisfied_returns_false_if_filter_true_when_a_user_filter_is_given(){
-        $user = $this->newUser(['id' => 1]);
-        $group = $this->newGroup(['id' => 2]);
-        $role = $this->newRole(['id' => 3]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
 
         $filter = $this->prophesize(FilterInstance::class);
         $filter->for()->shouldBeCalled()->willReturn('user');
@@ -55,9 +55,9 @@ class FilterFalseSpecificationTest extends TestCase
 
     /** @test */
     public function isSatisfied_returns_true_if_filter_false_when_a_group_filter_is_given(){
-        $user = $this->newUser(['id' => 1]);
-        $group = $this->newGroup(['id' => 2]);
-        $role = $this->newRole(['id' => 3]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
 
         $filter = $this->prophesize(FilterInstance::class);
         $filter->for()->shouldBeCalled()->willReturn('group');
@@ -75,9 +75,9 @@ class FilterFalseSpecificationTest extends TestCase
 
     /** @test */
     public function isSatisfied_returns_false_if_filter_true_when_a_group_filter_is_given(){
-        $user = $this->newUser(['id' => 1]);
-        $group = $this->newGroup(['id' => 2]);
-        $role = $this->newRole(['id' => 3]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
 
         $filter = $this->prophesize(FilterInstance::class);
         $filter->for()->shouldBeCalled()->willReturn('group');
@@ -95,9 +95,9 @@ class FilterFalseSpecificationTest extends TestCase
 
     /** @test */
     public function isSatisfied_returns_true_if_filter_false_when_a_role_filter_is_given(){
-        $user = $this->newUser(['id' => 1]);
-        $group = $this->newGroup(['id' => 2]);
-        $role = $this->newRole(['id' => 3]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
 
         $filter = $this->prophesize(FilterInstance::class);
         $filter->for()->shouldBeCalled()->willReturn('role');
@@ -115,9 +115,9 @@ class FilterFalseSpecificationTest extends TestCase
 
     /** @test */
     public function isSatisfied_returns_false_if_filter_true_when_a_role_filter_is_given(){
-        $user = $this->newUser(['id' => 1]);
-        $group = $this->newGroup(['id' => 2]);
-        $role = $this->newRole(['id' => 3]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
 
         $filter = $this->prophesize(FilterInstance::class);
         $filter->for()->shouldBeCalled()->willReturn('role');
@@ -135,9 +135,9 @@ class FilterFalseSpecificationTest extends TestCase
     
     /** @test */
     public function isSatisfied_returns_false_if_wrong_filter_type_given(){
-        $user = $this->newUser(['id' => 1]);
-        $group = $this->newGroup(['id' => 2]);
-        $role = $this->newRole(['id' => 3]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
 
         $filter = $this->prophesize(FilterInstance::class);
         $filter->for()->shouldBeCalled()->willReturn('notatype');

--- a/tests/Logic/Specification/FilterTrueSpecificationTest.php
+++ b/tests/Logic/Specification/FilterTrueSpecificationTest.php
@@ -16,9 +16,9 @@ class FilterTrueSpecificationTest extends TestCase
 
     /** @test */
     public function isSatisfied_returns_true_if_filter_true_when_a_user_filter_is_given(){
-        $user = $this->newUser(['id' => 1]);
-        $group = $this->newGroup(['id' => 2]);
-        $role = $this->newRole(['id' => 3]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
 
         $filter = $this->prophesize(FilterInstance::class);
         $filter->for()->shouldBeCalled()->willReturn('user');
@@ -36,9 +36,9 @@ class FilterTrueSpecificationTest extends TestCase
 
     /** @test */
     public function isSatisfied_returns_false_if_filter_false_when_a_user_filter_is_given(){
-        $user = $this->newUser(['id' => 1]);
-        $group = $this->newGroup(['id' => 2]);
-        $role = $this->newRole(['id' => 3]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
 
         $filter = $this->prophesize(FilterInstance::class);
         $filter->for()->shouldBeCalled()->willReturn('user');
@@ -56,9 +56,9 @@ class FilterTrueSpecificationTest extends TestCase
 
     /** @test */
     public function isSatisfied_returns_true_if_filter_true_when_a_group_filter_is_given(){
-        $user = $this->newUser(['id' => 1]);
-        $group = $this->newGroup(['id' => 2]);
-        $role = $this->newRole(['id' => 3]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
 
         $filter = $this->prophesize(FilterInstance::class);
         $filter->for()->shouldBeCalled()->willReturn('group');
@@ -76,9 +76,9 @@ class FilterTrueSpecificationTest extends TestCase
 
     /** @test */
     public function isSatisfied_returns_false_if_filter_false_when_a_group_filter_is_given(){
-        $user = $this->newUser(['id' => 1]);
-        $group = $this->newGroup(['id' => 2]);
-        $role = $this->newRole(['id' => 3]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
 
         $filter = $this->prophesize(FilterInstance::class);
         $filter->for()->shouldBeCalled()->willReturn('group');
@@ -96,9 +96,9 @@ class FilterTrueSpecificationTest extends TestCase
 
     /** @test */
     public function isSatisfied_returns_true_if_filter_true_when_a_role_filter_is_given(){
-        $user = $this->newUser(['id' => 1]);
-        $group = $this->newGroup(['id' => 2]);
-        $role = $this->newRole(['id' => 3]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
 
         $filter = $this->prophesize(FilterInstance::class);
         $filter->for()->shouldBeCalled()->willReturn('role');
@@ -116,9 +116,9 @@ class FilterTrueSpecificationTest extends TestCase
 
     /** @test */
     public function isSatisfied_returns_false_if_filter_false_when_a_role_filter_is_given(){
-        $user = $this->newUser(['id' => 1]);
-        $group = $this->newGroup(['id' => 2]);
-        $role = $this->newRole(['id' => 3]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
 
         $filter = $this->prophesize(FilterInstance::class);
         $filter->for()->shouldBeCalled()->willReturn('role');
@@ -136,9 +136,9 @@ class FilterTrueSpecificationTest extends TestCase
 
     /** @test */
     public function isSatisfied_returns_false_if_wrong_filter_type_given(){
-        $user = $this->newUser(['id' => 1]);
-        $group = $this->newGroup(['id' => 2]);
-        $role = $this->newRole(['id' => 3]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
 
         $filter = $this->prophesize(FilterInstance::class);
         $filter->for()->shouldBeCalled()->willReturn('notatype');

--- a/tests/ModuleInstance/Evaluator/ActivityInstanceEvaluatorTest.php
+++ b/tests/ModuleInstance/Evaluator/ActivityInstanceEvaluatorTest.php
@@ -24,9 +24,9 @@ class ActivityInstanceEvaluatorTest extends TestCase
         $activity->moduleInstances()->saveMany($moduleInstances);
         $activityInstance = factory(ActivityInstance::class)->create(['activity_id' => $activity->id]);
 
-        $user = $this->newUser(['id' => 1]);
-        $group = $this->newGroup(['id' => 2]);
-        $role = $this->newRole(['id' => 3]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
         
         $moduleInstanceEvaluator = $this->prophesize(ModuleInstanceEvaluator::class);
         $evaluation = $this->prophesize(Evaluation::class);
@@ -56,9 +56,9 @@ class ActivityInstanceEvaluatorTest extends TestCase
         $activity = factory(Activity::class)->create();
         $activity->moduleInstances()->saveMany($moduleInstances);
         $activityInstance = factory(ActivityInstance::class)->create(['activity_id' => $activity->id]);
-        $user = $this->newUser(['id' => 1]);
-        $group = $this->newGroup(['id' => 2]);
-        $role = $this->newRole(['id' => 3]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
         $moduleInstanceEvaluator = $this->prophesize(ModuleInstanceEvaluator::class);
         $evaluation = $this->prophesize(Evaluation::class);
         foreach ($moduleInstances as $moduleInstance) {

--- a/tests/ModuleInstance/Evaluator/ModuleInstanceEvaluatorTest.php
+++ b/tests/ModuleInstance/Evaluator/ModuleInstanceEvaluatorTest.php
@@ -77,9 +77,9 @@ class ModuleInstanceEvaluatorTest extends TestCase
         $evaluation->setActive(false)->shouldBeCalled();
         $evaluation->setComplete(true)->shouldBeCalled();
         $this->app->instance(Evaluation::class, $evaluation->reveal());
-        $user = $this->newUser(['id' => 1]);
-        $group = $this->newGroup(['id' => 2]);
-        $role = $this->newRole(['id' => 3]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
 
         $this->logicTester()->forLogic($moduleInstance->visibleLogic)->pass($user, $group, $role);
         $this->logicTester()->forLogic($moduleInstance->mandatoryLogic)->pass($user, $group, $role);
@@ -111,9 +111,9 @@ class ModuleInstanceEvaluatorTest extends TestCase
         $evaluation->setComplete(false)->shouldBeCalled();
         $this->app->instance(Evaluation::class, $evaluation->reveal());
 
-        $user = $this->newUser(['id' => 1]);
-        $group = $this->newGroup(['id' => 2]);
-        $role = $this->newRole(['id' => 3]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
 
         $this->logicTester()->forLogic($moduleInstance->visibleLogic)->pass($user, $group, $role);
         $this->logicTester()->forLogic($moduleInstance->activeLogic)->fail($user, $group, $role);
@@ -131,9 +131,9 @@ class ModuleInstanceEvaluatorTest extends TestCase
         $activityInstance->activity->moduleInstances()->save($moduleInstance);
         $evaluation = $this->prophesize(Evaluation::class);
 
-        $user = $this->newUser(['id' => 1]);
-        $group = $this->newGroup(['id' => 1]);
-        $role = $this->newRole(['id' => 2]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
         $logicTester = $this->prophesize(LogicTester::class);
         $logicTester->evaluate(Argument::that(function ($arg) use ($moduleInstance) {
             return $moduleInstance->visibleLogic->is($arg);

--- a/tests/Permissions/Contracts/TesterTest.php
+++ b/tests/Permissions/Contracts/TesterTest.php
@@ -16,9 +16,9 @@ class TesterTest extends TestCase
     /** @test */
     public function handle_calls_can_and_passes_the_correct_parameters()
     {
-        $user = new \BristolSU\ControlDB\Models\User(['id' => 1]);
-        $group = new \BristolSU\ControlDB\Models\Group(['id' => 2]);
-        $role = new \BristolSU\ControlDB\Models\Role(['id' => 3]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
 
         $tester = (new DummyTester())
             ->assertPermission(function ($arg) {
@@ -40,9 +40,9 @@ class TesterTest extends TestCase
     /** @test */
     public function handle_returns_true_if_can_is_true()
     {
-        $user = new \BristolSU\ControlDB\Models\User(['id' => 1]);
-        $group = new \BristolSU\ControlDB\Models\Group(['id' => 2]);
-        $role = new \BristolSU\ControlDB\Models\Role(['id' => 3]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
 
         $tester = (new DummyTester())->return(true);
 
@@ -54,9 +54,9 @@ class TesterTest extends TestCase
     /** @test */
     public function handle_returns_false_if_can_is_false()
     {
-        $user = new \BristolSU\ControlDB\Models\User(['id' => 1]);
-        $group = new \BristolSU\ControlDB\Models\Group(['id' => 2]);
-        $role = new \BristolSU\ControlDB\Models\Role(['id' => 3]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
 
         $tester = (new DummyTester())->return(false);
         $this->assertFalse(
@@ -68,9 +68,9 @@ class TesterTest extends TestCase
     public function handle_calls_handle_on_the_successor_if_the_result_is_null_and_a_successor_is_set()
     {
         $permission = new \BristolSU\Support\Permissions\Models\Permission('ability1');
-        $user = new \BristolSU\ControlDB\Models\User(['id' => 1]);
-        $group = new \BristolSU\ControlDB\Models\Group(['id' => 2]);
-        $role = new \BristolSU\ControlDB\Models\Role(['id' => 3]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
 
         $successor = $this->prophesize(Tester::class);
         $successor->handle($permission, $user, $group, $role)->shouldBeCalled()->willReturn(true);
@@ -86,9 +86,9 @@ class TesterTest extends TestCase
     public function handle_returns_null_if_the_result_is_null_and_no_successor_is_set()
     {
         $permission = new \BristolSU\Support\Permissions\Models\Permission('ability1');
-        $user = new \BristolSU\ControlDB\Models\User(['id' => 1]);
-        $group = new \BristolSU\ControlDB\Models\Group(['id' => 2]);
-        $role = new \BristolSU\ControlDB\Models\Role(['id' => 3]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
 
         $tester = (new DummyTester())->returnNull();
         $this->assertNull(

--- a/tests/Permissions/Models/ModelPermissionTest.php
+++ b/tests/Permissions/Models/ModelPermissionTest.php
@@ -33,9 +33,9 @@ class ModelPermissionTest extends TestCase
 
     /** @test */
     public function user_can_select_by_user_id_and_ability(){
-        $user1 = $this->newUser(['id' => 1]);
-        $user2 = $this->newUser(['id' => 2]);
-        $user4 = $this->newUser(['id' => 3]);
+        $user1 = $this->newUser();
+        $user2 = $this->newUser();
+        $user4 = $this->newUser();
         $userPermission1 = factory(ModelPermission::class)->state('user')->create(['ability' => 'permission1', 'model_id' => $user1->id]);
         $userPermission2 = factory(ModelPermission::class)->state('user')->create(['ability' => 'permission2', 'model_id' => $user2->id]);
         $userPermission3 = factory(ModelPermission::class)->state('user')->create(['ability' => 'permission3', 'model_id' => $user1->id]);
@@ -49,9 +49,9 @@ class ModelPermissionTest extends TestCase
 
     /** @test */
     public function group_can_select_by_group_id_and_ability(){
-        $group1 = $this->newGroup(['id' => 1]);
-        $group2 = $this->newGroup(['id' => 2]);
-        $group4 = $this->newGroup(['id' => 3]);
+        $group1 = $this->newGroup();
+        $group2 = $this->newGroup();
+        $group4 = $this->newGroup();
         $groupPermission1 = factory(ModelPermission::class)->state('group')->create(['ability' => 'permission1', 'model_id' => $group1->id]);
         $groupPermission2 = factory(ModelPermission::class)->state('group')->create(['ability' => 'permission2', 'model_id' => $group2->id]);
         $groupPermission3 = factory(ModelPermission::class)->state('group')->create(['ability' => 'permission3', 'model_id' => $group1->id]);
@@ -81,9 +81,9 @@ class ModelPermissionTest extends TestCase
 
     /** @test */
     public function role_can_select_by_role_id_and_ability(){
-        $role1 = $this->newRole(['id' => 1]);
-        $role2 = $this->newRole(['id' => 2]);
-        $role4 = $this->newRole(['id' => 3]);
+        $role1 = $this->newRole();
+        $role2 = $this->newRole();
+        $role4 = $this->newRole();
         $rolePermission1 = factory(ModelPermission::class)->state('role')->create(['ability' => 'permission1', 'model_id' => $role1->id]);
         $rolePermission2 = factory(ModelPermission::class)->state('role')->create(['ability' => 'permission2', 'model_id' => $role2->id]);
         $rolePermission3 = factory(ModelPermission::class)->state('role')->create(['ability' => 'permission3', 'model_id' => $role1->id]);
@@ -163,9 +163,9 @@ class ModelPermissionTest extends TestCase
 
     /** @test */
     public function user_can_select_by_user_id_and_ability_and_module_instance(){
-        $user1 = $this->newUser(['id' => 1]);
-        $user2 = $this->newUser(['id' => 2]);
-        $user4 = $this->newUser(['id' => 3]);
+        $user1 = $this->newUser();
+        $user2 = $this->newUser();
+        $user4 = $this->newUser();
         $userPermission1 = factory(ModelPermission::class)->state('user')->create(['ability' => 'permission1', 'model_id' => $user1->id, 'module_instance_id' => 1]);
         $userPermission2 = factory(ModelPermission::class)->state('user')->create(['ability' => 'permission2', 'model_id' => $user2->id]);
         $userPermission3 = factory(ModelPermission::class)->state('user')->create(['ability' => 'permission1', 'model_id' => $user1->id, 'module_instance_id' => 2]);
@@ -179,9 +179,9 @@ class ModelPermissionTest extends TestCase
 
     /** @test */
     public function group_can_select_by_group_id_and_ability_and_module_instance(){
-        $group1 = $this->newGroup(['id' => 1]);
-        $group2 = $this->newGroup(['id' => 2]);
-        $group4 = $this->newGroup(['id' => 3]);
+        $group1 = $this->newGroup();
+        $group2 = $this->newGroup();
+        $group4 = $this->newGroup();
         $groupPermission1 = factory(ModelPermission::class)->state('group')->create(['ability' => 'permission1', 'model_id' => $group1->id, 'module_instance_id' => 1]);
         $groupPermission2 = factory(ModelPermission::class)->state('group')->create(['ability' => 'permission2', 'model_id' => $group2->id]);
         $groupPermission3 = factory(ModelPermission::class)->state('group')->create(['ability' => 'permission1', 'model_id' => $group1->id, 'module_instance_id' => 2]);
@@ -195,9 +195,9 @@ class ModelPermissionTest extends TestCase
 
     /** @test */
     public function role_can_select_by_role_id_and_ability_and_module_instance(){
-        $role1 = $this->newRole(['id' => 1]);
-        $role2 = $this->newRole(['id' => 2]);
-        $role4 = $this->newRole(['id' => 3]);
+        $role1 = $this->newRole();
+        $role2 = $this->newRole();
+        $role4 = $this->newRole();
         $rolePermission1 = factory(ModelPermission::class)->state('role')->create(['ability' => 'permission1', 'model_id' => $role1->id, 'module_instance_id' => 1]);
         $rolePermission2 = factory(ModelPermission::class)->state('role')->create(['ability' => 'permission2', 'model_id' => $role2->id]);
         $rolePermission3 = factory(ModelPermission::class)->state('role')->create(['ability' => 'permission1', 'model_id' => $role1->id, 'module_instance_id' => 2]);
@@ -211,7 +211,7 @@ class ModelPermissionTest extends TestCase
 
     /** @test */
     public function moduleInstance_returns_the_module_instance(){
-        $role1 = $this->newRole(['id' => 1]);
+        $role1 = $this->newRole();
         $moduleInstance = factory(ModuleInstance::class)->create();
         $permission = factory(ModelPermission::class)->state('role')->create(['ability' => 'permission1', 'model_id' => $role1->id, 'module_instance_id' => $moduleInstance->id]);
         

--- a/tests/Permissions/PermissionTesterTest.php
+++ b/tests/Permissions/PermissionTesterTest.php
@@ -153,9 +153,9 @@ class PermissionTesterTest extends TestCase
     /** @test */
     public function evaluateFor_passes_the_models_through_to_the_tester()
     {
-        $user = new \BristolSU\ControlDB\Models\User(['id' => 1]);
-        $group = new \BristolSU\ControlDB\Models\Group(['id' => 2]);
-        $role = new \BristolSU\ControlDB\Models\Role(['id' => 3]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
 
         $tester = (new DummyTester())
             ->assertPermission(function ($arg) {
@@ -236,9 +236,9 @@ class PermissionTesterTest extends TestCase
     public function evaluate_takes_user_information_from_authentication_by_default()
     {
 
-        $user = new \BristolSU\ControlDB\Models\User(['id' => 1]);
-        $group = new \BristolSU\ControlDB\Models\Group(['id' => 2]);
-        $role = new \BristolSU\ControlDB\Models\Role(['id' => 3]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
 
         $authentication = $this->prophesize(Authentication::class);
         $authentication->getUser()->shouldBeCalled()->willReturn($user);
@@ -270,7 +270,7 @@ class PermissionTesterTest extends TestCase
     /** @test */
     public function evaluate_finds_the_correct_user_from_the_database_user_if_no_user_in_authentication()
     {
-        $user = $this->newUser(['id' => 1]);
+        $user = $this->newUser();
         $authentication = $this->prophesize(Authentication::class);
         $authentication->getUser()->shouldBeCalled()->willReturn(null);
         $authentication->getGroup()->shouldBeCalled()->willReturn(null);

--- a/tests/Permissions/Testers/ModuleInstanceGroupOverridePermissionTest.php
+++ b/tests/Permissions/Testers/ModuleInstanceGroupOverridePermissionTest.php
@@ -25,7 +25,7 @@ class ModuleInstanceGroupOverridePermissionTest extends TestCase
     /** @test */
     public function can_returns_null_if_no_module_instance_injected(){
         $tester = new ModuleInstanceGroupOverridePermission;
-        $group = $this->newGroup(['id' => 1]);
+        $group = $this->newGroup();
         $this->assertNull(
             $tester->can(new Permission('ability', '', '', 'module'), null, $group, null)
         );
@@ -34,7 +34,7 @@ class ModuleInstanceGroupOverridePermissionTest extends TestCase
     /** @test */
     public function can_returns_null_if_the_permission_is_not_module(){
         $tester = new ModuleInstanceGroupOverridePermission;
-        $group = $this->newGroup(['id' => 1]);
+        $group = $this->newGroup();
         $moduleInstance = factory(ModuleInstance::class)->create();
         $this->app->instance(ModuleInstance::class, $moduleInstance);
 
@@ -46,7 +46,7 @@ class ModuleInstanceGroupOverridePermissionTest extends TestCase
     /** @test */
     public function can_returns_true_if_there_is_a_system_override_in_the_database_with_a_true_result(){
         $tester = new ModuleInstanceGroupOverridePermission;
-        $group = $this->newGroup(['id' => 1]);
+        $group = $this->newGroup();
         $moduleInstance = factory(ModuleInstance::class)->create();
         $this->app->instance(ModuleInstance::class, $moduleInstance);
 
@@ -66,7 +66,7 @@ class ModuleInstanceGroupOverridePermissionTest extends TestCase
     /** @test */
     public function can_returns_false_if_there_is_a_system_override_in_the_database_with_a_false_result(){
         $tester = new ModuleInstanceGroupOverridePermission;
-        $group = $this->newGroup(['id' => 1]);
+        $group = $this->newGroup();
         $moduleInstance = factory(ModuleInstance::class)->create();
         $this->app->instance(ModuleInstance::class, $moduleInstance);
 
@@ -86,7 +86,7 @@ class ModuleInstanceGroupOverridePermissionTest extends TestCase
     /** @test */
     public function can_returns_null_if_there_is_no_system_override_in_the_database(){
         $tester = new ModuleInstanceGroupOverridePermission;
-        $group = $this->newGroup(['id' => 1]);
+        $group = $this->newGroup();
 
         $this->assertNull(
             $tester->can(new Permission('ability1', '', '', 'module'), null, $group, null)
@@ -96,7 +96,7 @@ class ModuleInstanceGroupOverridePermissionTest extends TestCase
     /** @test */
     public function can_returns_null_if_module_instance_id_not_in_permission_override(){
         $tester = new ModuleInstanceGroupOverridePermission;
-        $group = $this->newGroup(['id' => 1]);
+        $group = $this->newGroup();
         $moduleInstance = factory(ModuleInstance::class)->create();
         $this->app->instance(ModuleInstance::class, $moduleInstance);
 

--- a/tests/Permissions/Testers/ModuleInstancePermissionsTest.php
+++ b/tests/Permissions/Testers/ModuleInstancePermissionsTest.php
@@ -64,9 +64,9 @@ class ModuleInstancePermissionsTest extends TestCase
     /** @test */
     public function can_returns_true_if_the_logic_is_true()
     {
-        $user = $this->newUser(['id' => 1]);
-        $group = $this->newGroup(['id' => 2]);
-        $role = $this->newRole(['id' => 3]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
 
         $logic = factory(Logic::class)->create();
         $this->logicTester()->forLogic($logic)->pass($user, $group, $role);
@@ -86,9 +86,9 @@ class ModuleInstancePermissionsTest extends TestCase
     /** @test */
     public function can_returns_false_if_the_logic_is_false()
     {
-        $user = $this->newUser(['id' => 1]);
-        $group = $this->newGroup(['id' => 2]);
-        $role = $this->newRole(['id' => 3]);
+        $user = $this->newUser();
+        $group = $this->newGroup();
+        $role = $this->newRole();
 
         $logic = factory(Logic::class)->create();
         $this->logicTester()->forLogic($logic)->fail($user, $group, $role);

--- a/tests/Permissions/Testers/ModuleInstanceRoleOverridePermissionTest.php
+++ b/tests/Permissions/Testers/ModuleInstanceRoleOverridePermissionTest.php
@@ -25,7 +25,7 @@ class ModuleInstanceRoleOverridePermissionTest extends TestCase
     /** @test */
     public function can_returns_null_if_no_module_instance_injected(){
         $tester = new ModuleInstanceRoleOverridePermission;
-        $role = $this->newRole(['id' => 1]);
+        $role = $this->newRole();
         $this->assertNull(
             $tester->can(new Permission('ability', '', '', 'module'), null, null, $role)
         );
@@ -34,7 +34,7 @@ class ModuleInstanceRoleOverridePermissionTest extends TestCase
     /** @test */
     public function can_returns_null_if_the_permission_is_not_module(){
         $tester = new ModuleInstanceRoleOverridePermission;
-        $role = $this->newRole(['id' => 1]);
+        $role = $this->newRole();
         $moduleInstance = factory(ModuleInstance::class)->create();
         $this->app->instance(ModuleInstance::class, $moduleInstance);
 
@@ -46,7 +46,7 @@ class ModuleInstanceRoleOverridePermissionTest extends TestCase
     /** @test */
     public function can_returns_true_if_there_is_a_system_override_in_the_database_with_a_true_result(){
         $tester = new ModuleInstanceRoleOverridePermission;
-        $role = $this->newRole(['id' => 1]);
+        $role = $this->newRole();
         $moduleInstance = factory(ModuleInstance::class)->create();
         $this->app->instance(ModuleInstance::class, $moduleInstance);
 
@@ -66,7 +66,7 @@ class ModuleInstanceRoleOverridePermissionTest extends TestCase
     /** @test */
     public function can_returns_false_if_there_is_a_system_override_in_the_database_with_a_false_result(){
         $tester = new ModuleInstanceRoleOverridePermission;
-        $role = $this->newRole(['id' => 1]);
+        $role = $this->newRole();
         $moduleInstance = factory(ModuleInstance::class)->create();
         $this->app->instance(ModuleInstance::class, $moduleInstance);
 
@@ -86,7 +86,7 @@ class ModuleInstanceRoleOverridePermissionTest extends TestCase
     /** @test */
     public function can_returns_null_if_there_is_no_system_override_in_the_database(){
         $tester = new ModuleInstanceRoleOverridePermission;
-        $role = $this->newRole(['id' => 1]);
+        $role = $this->newRole();
 
         $this->assertNull(
             $tester->can(new Permission('ability1', '', '', 'module'), null, null, $role)
@@ -96,7 +96,7 @@ class ModuleInstanceRoleOverridePermissionTest extends TestCase
     /** @test */
     public function can_returns_null_if_module_instance_id_not_in_permission_override(){
         $tester = new ModuleInstanceRoleOverridePermission;
-        $role = $this->newRole(['id' => 1]);
+        $role = $this->newRole();
         $moduleInstance = factory(ModuleInstance::class)->create();
         $this->app->instance(ModuleInstance::class, $moduleInstance);
 

--- a/tests/Permissions/Testers/ModuleInstanceUserOverridePermissionTest.php
+++ b/tests/Permissions/Testers/ModuleInstanceUserOverridePermissionTest.php
@@ -26,7 +26,7 @@ class ModuleInstanceUserOverridePermissionTest extends TestCase
     /** @test */
     public function can_returns_null_if_no_module_instance_injected(){
         $tester = new ModuleInstanceUserOverridePermission;
-        $user = $this->newUser(['id' => 1]);
+        $user = $this->newUser();
         $this->assertNull(
             $tester->can(new Permission('ability', '', '', 'module'), $user, null, null)
         );
@@ -35,7 +35,7 @@ class ModuleInstanceUserOverridePermissionTest extends TestCase
     /** @test */
     public function can_returns_null_if_the_permission_is_not_module(){
         $tester = new ModuleInstanceUserOverridePermission;
-        $user = $this->newUser(['id' => 1]);
+        $user = $this->newUser();
         $moduleInstance = factory(ModuleInstance::class)->create();
         $this->app->instance(ModuleInstance::class, $moduleInstance);
         
@@ -47,7 +47,7 @@ class ModuleInstanceUserOverridePermissionTest extends TestCase
     /** @test */
     public function can_returns_true_if_there_is_a_system_override_in_the_database_with_a_true_result(){
         $tester = new ModuleInstanceUserOverridePermission;
-        $user = $this->newUser(['id' => 1]);
+        $user = $this->newUser();
         $moduleInstance = factory(ModuleInstance::class)->create();
         $this->app->instance(ModuleInstance::class, $moduleInstance);
 
@@ -67,7 +67,7 @@ class ModuleInstanceUserOverridePermissionTest extends TestCase
     /** @test */
     public function can_returns_false_if_there_is_a_system_override_in_the_database_with_a_false_result(){
         $tester = new ModuleInstanceUserOverridePermission;
-        $user = $this->newUser(['id' => 1]);
+        $user = $this->newUser();
         $moduleInstance = factory(ModuleInstance::class)->create();
         $this->app->instance(ModuleInstance::class, $moduleInstance);
 
@@ -87,7 +87,7 @@ class ModuleInstanceUserOverridePermissionTest extends TestCase
     /** @test */
     public function can_returns_null_if_there_is_no_system_override_in_the_database(){
         $tester = new ModuleInstanceUserOverridePermission;
-        $user = $this->newUser(['id' => 1]);
+        $user = $this->newUser();
 
         $this->assertNull(
             $tester->can(new Permission('ability1', '', '', 'module'), $user, null, null)
@@ -97,7 +97,7 @@ class ModuleInstanceUserOverridePermissionTest extends TestCase
     /** @test */
     public function can_returns_null_if_module_instance_id_not_in_permission_override(){
         $tester = new ModuleInstanceUserOverridePermission;
-        $user = $this->newUser(['id' => 1]);
+        $user = $this->newUser();
         $moduleInstance = factory(ModuleInstance::class)->create();
         $this->app->instance(ModuleInstance::class, $moduleInstance);
 

--- a/tests/Permissions/Testers/SystemUserPermissionTest.php
+++ b/tests/Permissions/Testers/SystemUserPermissionTest.php
@@ -23,7 +23,7 @@ class SystemUserPermissionTest extends TestCase
     /** @test */
     public function can_returns_null_if_the_permission_is_not_global(){
         $tester = new SystemUserPermission();
-        $user = $this->newUser(['id' => 1]);
+        $user = $this->newUser();
         
         $this->assertNull(
             $tester->can(new Permission('ability', '', '', 'module'), $user, null, null)
@@ -33,7 +33,7 @@ class SystemUserPermissionTest extends TestCase
     /** @test */
     public function can_returns_true_if_there_is_a_system_override_in_the_database_with_a_true_result(){
         $tester = new SystemUserPermission();
-        $user = $this->newUser(['id' => 1]);
+        $user = $this->newUser();
 
         ModelPermission::create([
             'ability' => 'ability1',
@@ -50,7 +50,7 @@ class SystemUserPermissionTest extends TestCase
     /** @test */
     public function can_returns_false_if_there_is_a_system_override_in_the_database_with_a_false_result(){
         $tester = new SystemUserPermission();
-        $user = $this->newUser(['id' => 1]);
+        $user = $this->newUser();
 
         ModelPermission::create([
             'ability' => 'ability1',
@@ -67,7 +67,7 @@ class SystemUserPermissionTest extends TestCase
     /** @test */
     public function can_returns_null_if_there_is_no_system_override_in_the_database(){
         $tester = new SystemUserPermission();
-        $user = $this->newUser(['id' => 1]);
+        $user = $this->newUser();
 
         $this->assertNull(
             $tester->can(new Permission('ability1'), $user, null, null)


### PR DESCRIPTION
We now save the current user ID in any of these four models
- Action Instance
- Activity
- Module Instance
- Logic

This lets us know who created the resource.